### PR TITLE
fix: 方案选择失败时重置配置文件

### DIFF
--- a/app/src/main/java/com/osfans/trime/settings/components/SchemaPickerDialog.kt
+++ b/app/src/main/java/com/osfans/trime/settings/components/SchemaPickerDialog.kt
@@ -10,6 +10,7 @@ import com.osfans.trime.R
 import com.osfans.trime.Rime
 import com.osfans.trime.ime.core.Trime
 import com.osfans.trime.settings.PrefMainActivity
+import com.osfans.trime.setup.Config
 import com.osfans.trime.util.RimeUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -122,7 +123,12 @@ class SchemaPickerDialog(
     }
 
     private fun initSchemas() {
-        if (schemaMapList.isNullOrEmpty()) return
+        if (schemaMapList.isNullOrEmpty()) {
+            // 尝试一次配置文件重置 缺失 default.custom.yaml 导致方案为空
+            Config.get(context).prepareRime(context)
+            schemaMapList = Rime.get_available_schema_list()
+            if (schemaMapList.isNullOrEmpty()) return
+        }
         schemaMapList!!.sortedWith(SortByName())
         val selectedSchemas = Rime.get_selected_schema_list()
         val selectedIds = ArrayList<String>()

--- a/app/src/main/java/com/osfans/trime/setup/Config.java
+++ b/app/src/main/java/com/osfans/trime/setup/Config.java
@@ -160,7 +160,7 @@ public class Config {
     return new File(getUserDataDir(), sub).getPath();
   }
 
-  private void prepareRime(Context context) {
+  public void prepareRime(Context context) {
     boolean isExist = new File(getSharedDataDir()).exists();
     boolean isOverwrite = AppVersionUtils.INSTANCE.isDifferentVersion(getPrefs());
     String defaultFile = "trime.yaml";


### PR DESCRIPTION
#454 修改后，存在用户在修改方案过程中误删 default.custom.yaml 场景。方案列表检查为空时进行一次配置文件重置，避免default.custom导致的方案部署问题

## PR Info
#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Manual testing
- [x] Done

#### Build tasks success
Successfully running following tasks on local
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Code Reviews
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Additional Info
