### PR TITLE
Fix candidate and liquid keyboard

### DIFF
--- a/app/src/main/assets/rime/tongwenfeng.trime.yaml
+++ b/app/src/main/assets/rime/tongwenfeng.trime.yaml
@@ -1001,8 +1001,8 @@ preset_keyboards:
       - {click: Keyboard_bqrw, long_click: Theme_settings, width: 12.5, key_text_size: "18", key_back_color: bgn, key_text_color: tgn}
       - {click: ',', label: '，', long_click: '<>{Left}', key_back_color: bh4, key_text_color: th4}
       - {click: space, long_click: Mode_switch, swipe_left: "Left", swipe_right: "Right", swipe_up: Schema_switchcn, width: 30, key_back_color: bkg, key_text_color: tkg}
-      - {click: '.', label: '。', long_click: Keyboard_kao, key_back_color: bh4, key_text_color: th4}
-      - {click: space_R2, long_click: liquid_keyboard_switch , key_text_size: "18", key_back_color: bh4, key_text_color: th4}
+      - {click: '.', label: '。', long_click: liquid_keyboard_clipboard, key_back_color: bh4, key_text_color: th4}
+      - {click: handwriting1, long_click: liquid_keyboard_switch , key_text_size: "18", key_back_color: bh4, key_text_color: th4}
       - {click: Return, swipe_up: Escape, width: 15, key_back_color: benter, key_text_color: tenter}
 
   letter:
@@ -3886,7 +3886,7 @@ preset_keys:
   cut: {label: 剪切, functional: false, send: Control+x}
   copy: {label: 复制, functional: false, send: Control+c}
   paste: {label: 粘贴, functional: false, send: Control+v}
-  paste_clip: {label: 剪贴板, send: function, command: clipboard}
+  paste_clip: {label: 粘贴, send: function, command: clipboard}
   paste_text: {label: 貼上文本, send: Control+Shift+Alt+v} #>=Android 6.0
   share_text: {label: 分享文本, send: Control+Alt+s} #>=Android 6.0
   redo: {label: 重做, functional: false, send: Control+y} #>=Android 6.0
@@ -3910,7 +3910,10 @@ preset_keys:
   Henkan: {toggle: simplification, send: Mode_switch, states: [ 汉字, 汉字 ]}
   Charset_switch: {toggle: extended_charset, send: Mode_switch, states: [ 常用, 增广 ]}
   Punct_switch: {toggle: ascii_punct, send: Mode_switch, states: [ 。，, ．， ]}
-  liquid_keyboard_switch: { toggle: _liquid_keyboard, send: Mode_switch, states: [ 更多, 普通 ] }
+  liquid_keyboard_switch: { toggle: _liquid_keyboard, send: Mode_switch, states: [ 更多, 更多 ] }
+  liquid_keyboard_clipboard: {label: 剪贴板, send: function, command: liquid_keyboard, option: "剪贴"}
+  handwriting: {toggle: _handwriting, send: Mode_switch, states: [ 手写, 手写 ] }
+  handwriting1: {toggle: _handwriting, send: Mode_switch, states: [ 写, 写 ] }
   # trime设置
   IME_switch: {label: 🌐, send: LANGUAGE_SWITCH} #彈出對話框選擇輸入法
   IME_last: {label: 上一输入法, send: LANGUAGE_SWITCH, select: .last} #直接切換到上一輸入法

--- a/app/src/main/assets/rime/trime.yaml
+++ b/app/src/main/assets/rime/trime.yaml
@@ -930,7 +930,7 @@ preset_keys:
   Keyboard_default: {label: 返回, send: Eisu_toggle, select: .default}
   Keyboard_switch: {label: 鍵盤, send: Eisu_toggle, select: .next}
   Schema_switch: {label: 下一方案, send: Control+Shift+1}
-  liquid_keyboard_switch: { toggle: _liquid_keyboard, send: Mode_switch, states: [ 更多, 普通 ] }
+  liquid_keyboard_switch: { toggle: _liquid_keyboard, send: Mode_switch, states: [ 更多, 更多 ] }
   one_hand_switch_1: {toggle: _one_hand_mode_1, send: Mode_switch, states: [ 左手, 普通 ]}
   one_hand_switch_2: {toggle: _one_hand_mode_2, send: Mode_switch, states: [ 右手, 普通 ]}
   one_hand_switch_3: {toggle: _one_hand_mode_3, send: Mode_switch, states: [ 左手, 右手 ]}

--- a/app/src/main/java/com/osfans/trime/ime/core/Preferences.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/Preferences.kt
@@ -292,6 +292,7 @@ class Preferences(
             const val SHOW_STATUS_BAR_ICON = "other__show_status_bar_icon"
             const val DESTROY_ON_QUIT = "other__destroy_on_quit"
             const val SELECTION_SENSE = "other__selection_sense"
+            const val CLICK_CANDIDATE_AND_COMMIT = "other__click_candidate_and_commit"
             const val CLIPBOARD_COMPARE_RULES = "other__clipboard_compare"
             const val CLIPBOARD_OUTPUT_RULES = "other__clipboard_output"
             const val CLIPBOARD_MANAGER_RULES = "other__clipboard_manager"
@@ -305,6 +306,9 @@ class Preferences(
         var selectionSense: Boolean
             get() = prefs.getPref(SELECTION_SENSE, true)
             set(v) = prefs.setPref(SELECTION_SENSE, v)
+        var clickCandidateAndCommit: Boolean
+            get() = prefs.getPref(CLICK_CANDIDATE_AND_COMMIT, true)
+            set(v) = prefs.setPref(CLICK_CANDIDATE_AND_COMMIT, v)
         var showStatusBarIcon: Boolean = false
             get() = prefs.getPref(SHOW_STATUS_BAR_ICON, false)
             private set

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -1257,8 +1257,13 @@ public class Trime extends InputMethodService
       }
     } else if (index == -4) onKey(KeyEvent.KEYCODE_PAGE_UP, 0);
     else if (index == -5) onKey(KeyEvent.KEYCODE_PAGE_DOWN, 0);
-    else // if (Rime.selectCandidate(index))
-    {
+    else if (getPrefs().getOther().getClickCandidateAndCommit() || index > 9) {
+      if (Rime.selectCandidate(index)) {
+        commitText();
+      }
+    } else if (index == 9) {
+      handleKey(KeyEvent.KEYCODE_0, 0);
+    } else {
       handleKey(KeyEvent.KEYCODE_1 + index, 0);
     }
   }

--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -114,7 +114,7 @@ public class Trime extends InputMethodService
   private Candidate mCandidate; // 候選
   private Composition mComposition; // 編碼
   private CompositionRootBinding compositionRootBinding = null;
-  private ScrollView mCandidateRoot;
+  private ScrollView mCandidateRoot, mTabRoot;
   private TabView tabView;
   private InputRootBinding inputRootBinding = null;
   private AlertDialog mOptionsDialog; // 對話框
@@ -436,7 +436,8 @@ public class Trime extends InputMethodService
 
         tabView.updateCandidateWidth();
         if (inputRootBinding != null) {
-          inputRootBinding.symbol.symbolInput.setBackground(mCandidateRoot.getBackground());
+          mTabRoot.setBackground(mCandidateRoot.getBackground());
+          mTabRoot.move(tabView.getHightlightLeft(), tabView.getHightlightRight());
         }
       } else symbolInputView.setVisibility(View.GONE);
     }
@@ -651,6 +652,7 @@ public class Trime extends InputMethodService
 
     // 初始化候选栏
     mCandidateRoot = inputRootBinding.main.candidateView.getRoot();
+    mTabRoot = inputRootBinding.symbol.tabView.getRoot();
     mCandidate = inputRootBinding.main.candidateView.candidates;
     mCandidate.setCandidateListener(this);
     mCandidateRoot.setPageStr(
@@ -1329,6 +1331,8 @@ public class Trime extends InputMethodService
       } else {
         mCandidate.setText(0);
       }
+      // 刷新候选词后，如果候选词超出屏幕宽度，滚动候选栏
+      mTabRoot.move(mCandidate.getHightlightLeft(), mCandidate.getHightlightRight());
     }
     if (mainKeyboardView != null) mainKeyboardView.invalidateComposingKeys();
     if (!onEvaluateInputViewShown()) setCandidatesViewShown(canCompose); // 實體鍵盤打字時顯示候選欄

--- a/app/src/main/java/com/osfans/trime/ime/symbol/TabManager.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/TabManager.java
@@ -29,6 +29,17 @@ public class TabManager {
     return self.tabTags.get(i);
   }
 
+  public static int getTagIndex(String name) {
+    if (name == null || name.length() < 1) return 0;
+    for (int i = 0; i < self.tabTags.size(); i++) {
+      TabTag tag = self.tabTags.get(i);
+      if (tag.text.equals(name)) {
+        return i;
+      }
+    }
+    return 0;
+  }
+
   private TabManager() {
     selected = 0;
     tabTags = new ArrayList<>();

--- a/app/src/main/java/com/osfans/trime/ime/symbol/TabView.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/TabView.java
@@ -29,7 +29,7 @@ import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
-import com.osfans.trime.Rime;
+import com.osfans.trime.ime.core.Trime;
 import com.osfans.trime.ime.enums.SymbolKeyboardType;
 import com.osfans.trime.setup.Config;
 import timber.log.Timber;
@@ -256,7 +256,7 @@ public class TabView extends View {
           if (tag.type == SymbolKeyboardType.NO_KEY) {
             switch (tag.command) {
               case EXIT:
-                Rime.toggleOption("_liquid_keyboard");
+                Trime.getService().selectLiquidKeyboard(-1);
                 break;
 
                 // TODO liquidKeyboard中除返回按钮外，其他按键均未实装
@@ -269,7 +269,7 @@ public class TabView extends View {
           } else if (System.currentTimeMillis() - time0 < 500) {
             highlightIndex = i;
             invalidate();
-            Rime.toggleOption("_liquid_keyboard_" + i);
+            Trime.getService().selectLiquidKeyboard(i);
           }
           Timber.d("index=" + i + " length=" + candidates.length);
         }

--- a/app/src/main/java/com/osfans/trime/ime/symbol/TabView.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/TabView.java
@@ -123,6 +123,14 @@ public class TabView extends View {
     }
   }
 
+  public int getHightlightLeft() {
+    return candidateRect[highlightIndex].left;
+  }
+
+  public int getHightlightRight() {
+    return candidateRect[highlightIndex].right;
+  }
+
   private Typeface getFont(int codepoint, Typeface font) {
     if (tfHanB != Typeface.DEFAULT && Character.isSupplementaryCodePoint(codepoint)) return tfHanB;
     if (tfLatin != Typeface.DEFAULT && codepoint < 0x2e80) return tfLatin;

--- a/app/src/main/java/com/osfans/trime/ime/text/Candidate.java
+++ b/app/src/main/java/com/osfans/trime/ime/text/Candidate.java
@@ -185,6 +185,18 @@ public class Candidate extends View {
     }
   }
 
+  public int getHightlightLeft() {
+    if (highlightIndex < candidateRect.length && highlightIndex >= 0)
+      return candidateRect[highlightIndex].left;
+    return 0;
+  }
+
+  public int getHightlightRight() {
+    if (highlightIndex < candidateRect.length && highlightIndex >= 0)
+      return candidateRect[highlightIndex].right;
+    return 0;
+  }
+
   private Typeface getFont(int codepoint, Typeface font) {
     if (hanBTypeface != Typeface.DEFAULT && Character.isSupplementaryCodePoint(codepoint))
       return hanBTypeface;

--- a/app/src/main/java/com/osfans/trime/ime/text/ScrollView.java
+++ b/app/src/main/java/com/osfans/trime/ime/text/ScrollView.java
@@ -10,6 +10,7 @@ import android.view.animation.TranslateAnimation;
 import android.widget.HorizontalScrollView;
 import androidx.annotation.NonNull;
 import com.osfans.trime.Rime;
+import timber.log.Timber;
 
 public class ScrollView extends HorizontalScrollView {
   private View inner;
@@ -92,15 +93,11 @@ public class ScrollView extends HorizontalScrollView {
         if (inner.getLeft() > 100 && Rime.hasLeft()) {
           if (pageUpAction != null) pageUpAction.run();
           if (inner.getWidth() > this.getWidth())
-            inner.layout(
-                this.getWidth() - inner.getWidth() - 400,
-                inner.getTop(),
-                this.getWidth() - 400,
-                inner.getBottom());
+            scrollTo(this.getWidth() - inner.getWidth() + 400, 0);
         } else if (inner.getWidth() - inner.getRight() > 100 && Rime.hasRight()) {
           if (pageDownAction != null) pageDownAction.run();
           if (inner.getWidth() > this.getWidth()) {
-            inner.layout(400, inner.getTop(), this.getWidth() + 400, inner.getBottom());
+            scrollTo(-400, 0);
           }
         } else {
           // When the scroll to the top or the most when it will not scroll, then move the layout.
@@ -156,6 +153,15 @@ public class ScrollView extends HorizontalScrollView {
   public void isNeedMove() {
     if (getScrollY() == 0) {
       isMoving = true;
+    }
+  }
+
+  public void move(int left, int right) {
+    Timber.i("ScroolView move(%s %s), scroll=%s", left, right, getScrollX());
+    if (right > getScrollX() + getWidth()) {
+      scrollTo(right - getWidth(), 0);
+    } else if (left < getScrollX()) {
+      scrollTo(left, 0);
     }
   }
 }

--- a/app/src/main/java/com/osfans/trime/util/ShortcutUtils.kt
+++ b/app/src/main/java/com/osfans/trime/util/ShortcutUtils.kt
@@ -16,6 +16,7 @@ import com.blankj.utilcode.util.ActivityUtils
 import com.blankj.utilcode.util.IntentUtils
 import com.osfans.trime.Rime
 import com.osfans.trime.ime.core.Preferences
+import com.osfans.trime.ime.core.Trime
 import java.text.FieldPosition
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -31,6 +32,7 @@ object ShortcutUtils {
             "clipboard" -> return pasteFromClipboard(context)
             "date" -> return getDate(option)
             "run" -> startIntent(option)
+            "liquid_keyboard" -> Trime.getService().selectLiquidKeyboard(option)
             else -> startIntent(command, option)
         }
         return null

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -157,4 +157,5 @@
     <string name="other__selection_sense_title">用 Ctrl+Left/Right 快速移动光标</string>
     <string name="pref__system_default">系统默认</string>
     <string name="keyboard__key_swipe_travel_title">触发滑动手势的最短距离</string>
+    <string name="other__click_candidate_and_commit">点击候选词时直接上屏</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -158,4 +158,5 @@
     <string name="other__selection_sense_title">使用 Ctrl+Left / Ctrl+Right 快速移動遊標</string>
     <string name="pref__system_default">系統預設</string>
     <string name="keyboard__key_swipe_travel_title">觸發滑動手勢的最短距離</string>
+    <string name="other__click_candidate_and_commit">點擊候選詞時直接上屏</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,4 +158,5 @@
     <string name="other__selection_sense_title">Uset Ctrl+Left/Right to move the cursor</string>
     <string name="pref__system_default">System Default</string>
     <string name="keyboard__key_swipe_travel_title">Min travel for gesture</string>
+    <string name="other__click_candidate_and_commit">Click candidate and commit directly</string>
 </resources>

--- a/app/src/main/res/xml/other_preference.xml
+++ b/app/src/main/res/xml/other_preference.xml
@@ -29,6 +29,10 @@
         app:iconSpaceReserved="false"
         android:title="@string/other__selection_sense_title" />
 
+    <SwitchPreferenceCompat android:key="other__click_candidate_and_commit"
+        app:iconSpaceReserved="false"
+        android:title="@string/other__click_candidate_and_commit" />
+
     <ListPreference
         android:defaultValue="100"
         app:iconSpaceReserved="false"


### PR DESCRIPTION
## PR Info
#### Issue tracker
1. 增加点击候选栏直接上屏/模拟发送数字键的开关
Fixes 点击候选行为变化 #524
2. 优化liquidKeyboard。 支持使用名称和序号两种方式打开指定的tab。打开指定tab'的方式由开关改为command。
3. 优化候选栏。 当普通键盘的高亮候选词、液态键盘的高亮tab在屏幕外时，自动调整候选栏的滚动位置。

#### Manual testing
- [x] Done

#### Build tasks success
Successfully running following tasks on local
- [x] [CONTRIBUTING](CONTRIBUTING.md)
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Code Reviews
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build for review
Fetch artifact after login

https://github.com/osfans/trime/actions

#### Additional Info
