### PR TITLE
Fix a ClassCastException caused by the clipboard command

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/core/Trime.java
+++ b/app/src/main/java/com/osfans/trime/ime/core/Trime.java
@@ -1016,7 +1016,7 @@ public class Trime extends InputMethodService
       commitText(commit, false); // 直接上屏，不發送給Rime
       return;
     }
-    String s = event.getText();
+    CharSequence s = event.getText();
     if (!TextUtils.isEmpty(s)) {
       onText(s);
       return;
@@ -1057,7 +1057,7 @@ public class Trime extends InputMethodService
         if (command.equals("liquid_keyboard")) {
           selectLiquidKeyboard(arg);
         } else {
-          s = (String) ShortcutUtils.INSTANCE.call(this, command, arg);
+          s = ShortcutUtils.INSTANCE.call(this, command, arg);
           if (s != null) {
             commitText(s);
             updateComposing();

--- a/app/src/main/java/com/osfans/trime/util/ShortcutUtils.kt
+++ b/app/src/main/java/com/osfans/trime/util/ShortcutUtils.kt
@@ -26,7 +26,7 @@ import java.util.Locale
  * Implementation to open/call specified application/function
  */
 object ShortcutUtils {
-    fun call(context: Context, command: String, option: String): Any? {
+    fun call(context: Context, command: String, option: String): CharSequence? {
         when (command) {
             "broadcast" -> context.sendBroadcast(Intent(option))
             "clipboard" -> return pasteFromClipboard(context)


### PR DESCRIPTION
The pasteFromClipboard function will return a non-String CharSequence if we copied a rich-text

## PR Info
#### Issue tracker
Fixes will automatically close the related issue

#### Manual testing
- [x] Done

#### Build tasks success
Successfully running following tasks on local
- [x] [CONTRIBUTING](CONTRIBUTING.md)
- [ ] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Code Reviews
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build for review
Fetch artifact after login

https://github.com/osfans/trime/actions

#### Additional Info

`./gradlew spotlessCheck` 失败是因为：

```
Step 'removeUnusedImports' found problem in 'app/src/main/java/com/osfans/trime/clipboard/ClipboardAdapter.java':
```

但这不是本次 PR 所引入的，为了整洁就不在这个 PR 修了

将 `ShortcutUtils.call` 的 `Any` 改为 `CharSequence` 是为了更准确的编译器检查，因为在实际调用的地方没有 `CharSequence` 之外的需求