### PR TITLE
fix(KeyboardView): multpoint touch wrongly recognized as swipe

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.java
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardView.java
@@ -165,6 +165,7 @@ public class KeyboardView extends View implements View.OnClickListener, Coroutin
   private int mStartX;
   private int mStartY;
   private int touchX0, touchY0;
+  private boolean touchOnePoint;
 
   private boolean mProximityCorrectOn;
 
@@ -1356,6 +1357,7 @@ public class KeyboardView extends View implements View.OnClickListener, Coroutin
       case MotionEvent.ACTION_DOWN:
         touchX0 = touchX;
         touchY0 = touchY;
+        touchOnePoint = true;
       case MotionEvent.ACTION_POINTER_DOWN:
         mAbortKey = false;
         mStartX = touchX;
@@ -1369,6 +1371,7 @@ public class KeyboardView extends View implements View.OnClickListener, Coroutin
         mDownKey = keyIndex;
         mDownTime = me.getEventTime();
         mLastMoveTime = mDownTime;
+        touchOnePoint = false;
         if (action == MotionEvent.ACTION_POINTER_DOWN) break; // 並擊鬆開前的虛擬按鍵事件
         checkMultiTap(eventTime, keyIndex);
         mKeyboardActionListener.onPress(keyIndex != NOT_A_KEY ? mKeys[keyIndex].getCode() : 0);
@@ -1444,7 +1447,7 @@ public class KeyboardView extends View implements View.OnClickListener, Coroutin
         int absY = Math.abs(dy);
         int travel = getPrefs().getKeyboard().getSwipeTravel();
 
-        if (Math.max(absY, absX) > travel) {
+        if (Math.max(absY, absX) > travel && touchOnePoint) {
           int type;
           if (absX < absY) {
             Timber.d("swipeDebug.ext y, dX=%d, dY=%d", dx, dy);


### PR DESCRIPTION
## PR Info
#### Issue tracker
修复多点触摸手势被错误识别为滑动手势的问题

Fixes #553 

#### Manual test
- [x] Done

#### Build tasks success
Successfully running following tasks on local
- [x] [CONTRIBUTING](CONTRIBUTING.md)

The tasks should be checked in every commit
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew assembleDebug`

#### Code Reviews
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build for review
Fetch artifact after login

https://github.com/osfans/trime/actions

#### Additional Info

