### PR TITLE
增加用户文件夹转移功能，将外部目录的文件转移到内部目录文件以提高用户隐私保护性

### DIFF
--- a/app/src/main/java/com/osfans/trime/data/base/DataManager.kt
+++ b/app/src/main/java/com/osfans/trime/data/base/DataManager.kt
@@ -50,9 +50,17 @@ object DataManager {
 
     val sharedDataDir = File(appContext.getExternalFilesDir(null), "shared").also { it.mkdirs() }
 
-    val userDataDir
-        get() = File(prefs.profile.userDataDir).also { it.mkdirs() }
-
+    val userDataDir: File
+        get() {
+            val prefs = AppPrefs.defaultInstance().profile
+            return if (prefs.useInternalStorage) {
+                // 使用应用内部存储
+                File(appContext.filesDir, "user_data").also { it.mkdirs() }
+            } else {
+                // 使用外部存储（原有行为）
+                File(prefs.userDataDir).also { it.mkdirs() }
+            }
+        }
     /**
      * Return the absolute path of the compiled config file
      * based on given resource id.

--- a/app/src/main/java/com/osfans/trime/data/prefs/AppPrefs.kt
+++ b/app/src/main/java/com/osfans/trime/data/prefs/AppPrefs.kt
@@ -31,7 +31,7 @@ class AppPrefs(
         providers.add(provider)
         return provider
     }
-
+    
     private fun <T : PreferenceDelegateProvider> T.register() =
         this.apply {
             registerProvider { this }
@@ -223,6 +223,8 @@ class AppPrefs(
             const val PERIODIC_BACKGROUND_SYNC_INTERVAL = "periodic_background_sync_interval"
             const val LAST_BACKGROUND_SYNC_STATUS = "last_background_sync_status"
             const val LAST_BACKGROUND_SYNC_TIME = "last_background_sync_time"
+            const val USE_INTERNAL_STORAGE = "use_internal_storage"
+            const val INTERNAL_STORAGE_FIRST_IMPORT = "internal_storage_first_import"  // 新增常量
         }
 
         var userDataDir by string(USER_DATA_DIR, DataManager.defaultDataDirectory.path)
@@ -230,6 +232,8 @@ class AppPrefs(
         val periodicBackgroundSyncInterval = int(PERIODIC_BACKGROUND_SYNC_INTERVAL, 30)
         val lastBackgroundSyncStatus = bool(LAST_BACKGROUND_SYNC_STATUS, false)
         val lastBackgroundSyncTime = long(LAST_BACKGROUND_SYNC_TIME, 0L)
+        val useInternalStorage by bool(USE_INTERNAL_STORAGE, false)
+        var internalStorageFirstImport by bool(INTERNAL_STORAGE_FIRST_IMPORT, false)
     }
 
     class Clipboard(
@@ -242,6 +246,7 @@ class AppPrefs(
             const val DRAFT_EXCLUDE_APP = "clipboard_draft_exclude_app"
             const val DRAFT_LIMIT = "clipboard_draft_limit"
             const val CLIPBOARD_LIMIT = "clipboard_clipboard_limit"
+
         }
 
         var clipboardCompareRules by string(CLIPBOARD_COMPARE_RULES, "")
@@ -250,6 +255,7 @@ class AppPrefs(
         var clipboardLimit by int(CLIPBOARD_LIMIT, 10)
         var draftLimit by int(DRAFT_LIMIT, 10)
         var draftExcludeApp by string(DRAFT_EXCLUDE_APP, "")
+
     }
 
     /**

--- a/app/src/main/java/com/osfans/trime/data/prefs/PreferenceDelegate.kt
+++ b/app/src/main/java/com/osfans/trime/data/prefs/PreferenceDelegate.kt
@@ -10,6 +10,7 @@ import com.osfans.trime.util.WeakHashSet
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
+
 open class PreferenceDelegate<T : Any>(
     val sharedPreferences: SharedPreferences,
     val key: String,

--- a/app/src/main/java/com/osfans/trime/ui/fragments/ProfileFragment.kt
+++ b/app/src/main/java/com/osfans/trime/ui/fragments/ProfileFragment.kt
@@ -31,6 +31,10 @@ import com.osfans.trime.util.toast
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.io.File
+import android.content.Context
+import com.osfans.trime.data.prefs.AppPrefs.Profile
+
 
 class ProfileFragment : PaddingPreferenceFragment() {
     private val viewModel: MainViewModel by activityViewModels()
@@ -58,14 +62,78 @@ class ProfileFragment : PaddingPreferenceFragment() {
                 viewModel.restartBackgroundSyncWork.value = true
             }
         }
-
+    private suspend fun importData(context: Context) {
+        withContext(Dispatchers.IO) {
+            val externalDir = File(prefs.userDataDir)
+            val internalDir = File(appContext.filesDir, "user_data")
+            internalDir.mkdirs()
+            externalDir.copyRecursively(internalDir, overwrite = true)
+        }
+        context.toast(R.string.import_success)
+    }
+    private val onInternalStorageChange =
+        PreferenceDelegate.OnChangeListener<Boolean> { _, newValue ->
+            if (newValue && !prefs.internalStorageFirstImport) {
+                // 只在首次开启内部存储模式时询问用户是否导入数据
+                AlertDialog.Builder(requireContext())
+                    .setTitle(R.string.import_data_title)
+                    .setMessage(R.string.import_data_message)
+                    .setPositiveButton(R.string.yes) { _, _ ->
+                        lifecycleScope.withLoadingDialog(requireContext()) {
+                            importData(requireContext())
+                            // 设置首次导入标记为 true
+                            prefs.internalStorageFirstImport  = true
+                        }
+                    }
+                    .setNegativeButton(R.string.no) { _, _ ->
+                        // 用户选择不导入数据，也设置首次导入标记为 true
+                        prefs.internalStorageFirstImport = true
+                    }
+                    .show()
+            }
+        }
     override fun onCreatePreferences(
         savedInstanceState: Bundle?,
         rootKey: String?,
     ) {
         addPreferencesFromResource(R.xml.profile_preference)
         prefs.periodicBackgroundSyncInterval.registerOnChangeListener(onSyncIntervalChange)
+        val useInternalStorageDelegate = prefs.preferenceDelegates[Profile.USE_INTERNAL_STORAGE] as? PreferenceDelegate<Boolean>
+        useInternalStorageDelegate?.registerOnChangeListener(onInternalStorageChange)
         with(preferenceScreen) {
+            get<Preference>("import_user_data")?.setOnPreferenceClickListener {
+                lifecycleScope.launch {
+                    val externalDir = File(prefs.userDataDir)
+                    val internalDir = File(appContext.filesDir, "user_data")
+
+                    lifecycleScope.withLoadingDialog(requireContext()) {
+                        withContext(Dispatchers.IO) {
+                            internalDir.mkdirs()
+                            externalDir.copyRecursively(internalDir, overwrite = true)
+                            context.toast(R.string.import_success)
+                        }
+                    }
+                }
+                true
+            }
+            get<Preference>("export_user_data")?.setOnPreferenceClickListener {
+                lifecycleScope.launch {
+                    val internalDir = File(appContext.filesDir, "user_data")
+                    val externalDir = File(prefs.userDataDir)
+
+                    lifecycleScope.withLoadingDialog(requireContext()) {
+                        withContext(Dispatchers.IO) {
+                            if (internalDir.exists()) {
+                                internalDir.copyRecursively(externalDir, overwrite = true)
+                                context.toast(R.string.export_success)
+                            } else {
+                                context.toast(R.string.export_failure)
+                            }
+                        }
+                    }
+                }
+                true
+            }
             get<FolderPickerPreference>("profile_user_data_dir")?.apply {
                 setDefaultValue(DataManager.defaultDataDirectory.path)
                 registerDocumentTreeLauncher()
@@ -99,14 +167,14 @@ class ProfileFragment : PaddingPreferenceFragment() {
                 val items = appContext.assets.list(base)!!
                 val checkedItems = items.map { false }.toBooleanArray()
                 AlertDialog
-                    .Builder(context)
+                    .Builder(requireContext())
                     .setTitle(R.string.profile_reset)
                     .setMultiChoiceItems(items, checkedItems) { _, id, isChecked ->
                         checkedItems[id] = isChecked
                     }.setNegativeButton(android.R.string.cancel, null)
                     .setPositiveButton(android.R.string.ok) { _, _ ->
                         var res = true
-                        lifecycleScope.withLoadingDialog(context) {
+                        lifecycleScope.withLoadingDialog(requireContext()) {
                             withContext(Dispatchers.IO) {
                                 res =
                                     items
@@ -129,5 +197,8 @@ class ProfileFragment : PaddingPreferenceFragment() {
     override fun onPause() {
         super.onPause()
         prefs.periodicBackgroundSyncInterval.unregisterOnChangeListener(onSyncIntervalChange)
+        val useInternalStorageDelegate = prefs.preferenceDelegates[Profile.USE_INTERNAL_STORAGE] as PreferenceDelegate<Boolean>
+        useInternalStorageDelegate.unregisterOnChangeListener(onInternalStorageChange)
+
     }
 }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -224,4 +224,17 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="navbar_bkg_none">无背景</string>
     <string name="navbar_bkg_color_only">跟随键盘背景色</string>
     <string name="navbar_bkg_full">键盘背景图片</string>
+    <string name="use_internal_storage">使用内部存储</string>  
+    <string name="use_internal_storage_summary">将用户数据存储在应用程序内部目录中，以更好地保护隐私</string>  
+    <string name="export_user_data">导出用户数据</string>  
+    <string name="export_user_data_summary">导出用户数据，用于多设备同步</string>
+    <string name="import_user_data">导入用户数据</string>  
+    <string name="import_user_data_summary">将用户数据从外部存储导入到内部存储</string>
+    <string name="import_data_title">导入数据</string>  
+    <string name="import_data_message">是否要从外部存储导入数据到内部存储？</string>  
+    <string name="import_success">数据导入成功</string>  
+    <string name="export_success">数据导出成功</string>  
+    <string name="export_failure">数据导出失败</string>  
+    <string name="yes">是</string>  
+    <string name="no">否</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -224,4 +224,17 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="navbar_bkg_none">無背景</string>
     <string name="navbar_bkg_color_only">跟隨鍵盤背景色</string>
     <string name="navbar_bkg_full">鍵盤背景圖片</string>
+    <string name="use_internal_storage">使用内部存储</string>  
+    <string name="use_internal_storage_summary">将用户数据存储在应用程序内部目录中，以更好地保护隐私</string>  
+    <string name="export_user_data">导出用户数据</string>  
+    <string name="export_user_data_summary">导出用户数据，用于多设备同步</string>
+    <string name="import_user_data">导入用户数据</string>  
+    <string name="import_user_data_summary">将用户数据从外部存储导入到内部存储</string>
+    <string name="import_data_title">导入数据</string>  
+    <string name="import_data_message">是否要从外部存储导入数据到内部存储？</string>  
+    <string name="import_success">数据导入成功</string>  
+    <string name="export_success">数据导出成功</string>  
+    <string name="export_failure">数据导出失败</string>  
+    <string name="yes">是</string>  
+    <string name="no">否</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -226,4 +226,17 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="navbar_bkg_none">No background</string>
     <string name="navbar_bkg_color_only">Follow keyboard color</string>
     <string name="navbar_bkg_full">Keyboard background image</string>
+    <string name="use_internal_storage">Use internal storage</string>  
+    <string name="use_internal_storage_summary">Store user data in app internal directory for better privacy</string>  
+    <string name="export_user_data">Export user data</string>  
+    <string name="export_user_data_summary">Export user data for multi-device synchronization</string>
+    <string name="import_user_data">Import user data</string>  
+    <string name="import_user_data_summary">Import user data from external storage to internal storage</string>
+    <string name="import_data_title">Import Data</string>  
+    <string name="import_data_message">Do you want to import data from external storage to internal storage?</string>  
+    <string name="yes">Yes</string>  
+    <string name="no">No</string>  
+    <string name="import_success">Data imported successfully</string>  
+    <string name="export_success">Data exported successfully</string>  
+    <string name="export_failure">Failed to export data</string>
 </resources>

--- a/app/src/main/res/xml/profile_preference.xml
+++ b/app/src/main/res/xml/profile_preference.xml
@@ -18,6 +18,23 @@ SPDX-License-Identifier: GPL-3.0-or-later
             android:title="@string/profile_user_data_dir"
             app:persistent="true"
             app:useSimpleSummaryProvider="true" />
+
+        <!-- 新增的存储开关 -->
+        <SwitchPreferenceCompat
+            android:key="use_internal_storage"
+            app:iconSpaceReserved="false"
+            android:title="@string/use_internal_storage"
+            android:summary="@string/use_internal_storage_summary" />
+        <!-- 新增的数据导入 -->
+        <Preference android:key="import_user_data"  
+            app:iconSpaceReserved="false"  
+            android:title="@string/import_user_data"  
+            android:summary="@string/import_user_data_summary" />
+        <!-- 新增的数据导出 -->
+        <Preference android:key="export_user_data"  
+            app:iconSpaceReserved="false"  
+            android:title="@string/export_user_data"  
+            android:summary="@string/export_user_data_summary" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/synchronization"


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #
Fixes #

#### Feature
在配置中增加了3个键，
1、使用内部存储将优先使用程序内部目录的数据。
2、导入用户数据会将外部目录的数据复制到内部目录。
3、导出用户数据会将内部目录的数据复制到外部目录。
4、完成导入后就可以将外部目录的配置文件夹删除了。

#### Code of conduct
- [ ] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [ ] `make sytle-lint`
- [ ] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [ ] `make debug`

#### Manually test
- [ ] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

