### PR TITLE
refactor: always generate builtin default.custom.yaml in user data dir

### DIFF
--- a/app/src/main/assets/shared/default.custom.yaml
+++ b/app/src/main/assets/shared/default.custom.yaml
@@ -1,4 +1,0 @@
-patch:
-  schema_list:
-    - schema: luna_pinyin
-    - schema: luna_pinyin_simp

--- a/app/src/main/java/com/osfans/trime/data/base/DataManager.kt
+++ b/app/src/main/java/com/osfans/trime/data/base/DataManager.kt
@@ -18,9 +18,17 @@ import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
 object DataManager {
+    private const val DEFAULT_FILE_NAME = "default.yaml"
     private const val DEFAULT_CUSTOM_FILE_NAME = "default.custom.yaml"
 
     private const val DATA_CHECKSUMS_NAME = "checksums.json"
+
+    private const val CUSTOM_PATCH = """
+      patch:
+        schema_list:
+          - schema: luna_pinyin
+          - schema: luna_pinyin_simp
+    """
 
     private val lock = ReentrantLock()
 
@@ -97,6 +105,14 @@ object DataManager {
         }
 
         ResourceUtils.copyFile(DATA_CHECKSUMS_NAME, dataDir.resolve(DATA_CHECKSUMS_NAME).absolutePath)
+
+        val default = userDataDir.resolve(DEFAULT_FILE_NAME)
+        val custom = userDataDir.resolve(DEFAULT_CUSTOM_FILE_NAME)
+        if (!default.exists() && !custom.exists()) {
+            if (custom.createNewFile()) {
+                custom.writeText(CUSTOM_PATCH.trimIndent())
+            }
+        }
 
         Timber.d("Synced!")
     }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes # N/A

#### Feature
Describe features of this pull request

Rime only output schema lists when there is a default.custom.yaml in user dir by design. So we need make user there is a `default.custom.yaml` file in the user data dir, then the schema list page will not be empty.

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

