### PR TITLE
Revert "deps: drop snappy"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,6 +5,9 @@
 [submodule "OpenCC"]
 	path = app/src/main/jni/OpenCC
 	url = https://github.com/BYVoid/OpenCC.git
+[submodule "snappy"]
+	path = app/src/main/jni/snappy
+	url = https://github.com/google/snappy.git
 [submodule "librime"]
 	path = app/src/main/jni/librime
 	url = https://github.com/rime/librime.git

--- a/app/src/main/jni/CMakeLists.txt
+++ b/app/src/main/jni/CMakeLists.txt
@@ -32,6 +32,13 @@ option(YAML_CPP_BUILD_TESTS "" OFF)
 option(YAML_CPP_INSTALL "" OFF)
 add_subdirectory(librime/deps/yaml-cpp)
 
+# enable compress for leveldb
+option(SNAPPY_BUILD_TESTS "" OFF)
+option(SNAPPY_BUILD_BENCHMARKS "" OFF)
+option(SNAPPY_INSTALL "" OFF)
+add_subdirectory(snappy)
+
+set(HAVE_SNAPPY TRUE)
 option(LEVELDB_BUILD_TESTS "" OFF)
 option(LEVELDB_BUILD_BENCHMARKS "" OFF)
 option(LEVELDB_INSTALL "" OFF)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes # N/A

#### Feature
Describe features of this pull request

This reverts commit bf7f53a034b495776e8b5e42ea943a43e746694a.

Some users feedback they cannot get or create a user word on the nighly app after the commit. It seems that leveldb will enable compression by default once it's built with compression library (like snappy here) even developers don't enable it explictally.

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

