### PR TITLE
fix: key state not updated after `composing` & `has_menu` state compl…

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardWindow.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardWindow.kt
@@ -12,6 +12,7 @@ import android.widget.FrameLayout
 import androidx.core.content.ContextCompat
 import com.osfans.trime.R
 import com.osfans.trime.core.RimeMessage
+import com.osfans.trime.core.RimeProto
 import com.osfans.trime.core.SchemaItem
 import com.osfans.trime.daemon.RimeSession
 import com.osfans.trime.data.theme.KeyActionManager
@@ -258,6 +259,13 @@ class KeyboardWindow(
         // TODO: 启用自动首句大写后，点击方向键时，保持Shift锁定状态功能将无法生效
         if (theme.generalStyle.autoCaps && status.isAsciiMode && currentKeyboardView?.isCapsOn == false) {
             setShift(false, cursorCapsMode != 0)
+        }
+    }
+
+    override fun onCompositionUpdate(data: RimeProto.Context.Composition) {
+        val status = rime.run { statusCached }
+        if (!status.isAsciiMode && data.length == 0 && data.preedit.isNullOrEmpty()) {
+            currentKeyboardView?.invalidateAllKeys()
         }
     }
 


### PR DESCRIPTION
…eted

<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #1805
Fixes #

#### Feature
Describe features of this pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

