### PR TITLE
fix(keyboard): resolve GestureFrame gaining focus unexpectedly

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/keyboard/GestureFrame.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/GestureFrame.kt
@@ -62,6 +62,9 @@ open class GestureFrame(context: Context) : FrameLayout(context) {
         // disable system sound effect and haptic feedback
         isSoundEffectsEnabled = false
         isHapticFeedbackEnabled = false
+        // avoid gaining focus unexpectedly
+        isFocusable = false
+        isFocusableInTouchMode = false
     }
 
     fun getSwipeDirection(dx: Float, dy: Float): SwipeDirection = if (abs(dx) > abs(dy)) {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #
Fixes #

#### Feature
Describe features of this pull request

Fix the issue that the views inherited from GestureFrame (like toolbar buttons) unexpectedly gains focus when the keyboard is invoked in certain applications, which interferes with normal user typing and can cause unintended button activation.

#### Code of conduct
- [ ] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [ ] `make sytle-lint`
- [ ] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [ ] `make debug`

#### Manually test
- [ ] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

