### PR TITLE
fix(keyboard): resolve schema name not refreshing when switching inpu…

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyAction.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyAction.kt
@@ -110,11 +110,9 @@ class KeyAction(
                 return adjustCase(shiftLabel, keyboard)
             }
         }
-        val currentLabel = label.ifEmpty {
-            // 特殊处理空格键：如果label为空且是空格键，尝试获取最新的schemaName
-            getSpaceKeySchemaName().takeIf { code == KeyEvent.KEYCODE_SPACE } ?: label
-        }
-        return adjustCase(currentLabel, keyboard)
+        // 仅在为空格键且 label 为空时才去查询 schema 名称，先检查键码以减少无谓计算
+        val displayLabel = takeIf { code == KeyEvent.KEYCODE_SPACE && label.isEmpty() }?.let { getSpaceKeySchemaName() } ?: label
+        return adjustCase(displayLabel, keyboard)
     }
 
     fun getText(keyboard: Keyboard): String = if (text.isNotEmpty()) {
@@ -161,7 +159,7 @@ class KeyAction(
                 if (label.isEmpty()) {
                     label =
                         when (code) {
-                            KeyEvent.KEYCODE_SPACE -> getSpaceKeySchemaName()
+                            KeyEvent.KEYCODE_SPACE -> ""
                             KeyEvent.KEYCODE_UNKNOWN -> ""
                             else -> Keycode.getDisplayLabel(code, modifier)
                         }
@@ -191,7 +189,7 @@ class KeyAction(
                 } else if (label.isEmpty()) {
                     label =
                         when (code) {
-                            KeyEvent.KEYCODE_SPACE -> getSpaceKeySchemaName()
+                            KeyEvent.KEYCODE_SPACE -> ""
                             KeyEvent.KEYCODE_UNKNOWN -> ""
                             else -> Keycode.getDisplayLabel(code, modifier)
                         }


### PR DESCRIPTION
…t methods after librime update

After the librime update, the schema name displayed on the space key would not refresh when switching input methods. The previous fix in PR #1810 directly set KeyAction.label to the schema name during initialization (when label was empty), using getSpaceKeySchemaName() as a fallback.

However, when users switch input methods at runtime, Rime's status (statusCached.schemaName) changes, but KeyAction.label remains set to the old name and is no longer empty. As a result, getLabel() doesn't re-read getSpaceKeySchemaName(), leaving the interface displaying the old name until a keyboard rebuild or refresh is triggered by another operation.

This change ensures that the space key's label isn't permanently fixed to a specific schema name during initialization, preventing the issue of "old values being cached". Now the schema name will correctly update when users switch input methods.

<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #
Fixes #

#### Feature
Describe features of this pull request

#### Code of conduct
- [ ] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [ ] `make sytle-lint`
- [ ] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [ ] `make debug`

#### Manually test
- [ ] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

