### PR TITLE
fix(candidates): unroll button was still visible when candidates is few

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/candidates/compact/CompactCandidateModule.kt
+++ b/app/src/main/java/com/osfans/trime/ime/candidates/compact/CompactCandidateModule.kt
@@ -60,7 +60,7 @@ class CompactCandidateModule(
         bar.unrollButtonStateMachine.push(
             UnrollButtonStateMachine.TransitionEvent.UnrolledCandidatesUpdated,
             UnrollButtonStateMachine.BooleanKey.UnrolledCandidatesEmpty to
-                (childCount == 0),
+                (adapter.itemCount == childCount),
         )
     }
 

--- a/app/src/main/java/com/osfans/trime/ime/candidates/unrolled/window/BaseUnrolledCandidateWindow.kt
+++ b/app/src/main/java/com/osfans/trime/ime/candidates/unrolled/window/BaseUnrolledCandidateWindow.kt
@@ -31,7 +31,6 @@ import com.osfans.trime.ime.core.TrimeInputMethodService
 import com.osfans.trime.ime.keyboard.KeyboardWindow
 import com.osfans.trime.ime.window.BoardWindow
 import com.osfans.trime.ime.window.BoardWindowManager
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import splitties.dimensions.dp
@@ -101,7 +100,12 @@ abstract class BaseUnrolledCandidateWindow(
         offsetJob =
             lifecycleCoroutineScope.launch {
                 compactCandidate.unrolledCandidateOffset.collect {
-                    updateCandidatesWithOffset(it)
+                    if (it <= 0) {
+                        windowManager.attachWindow(KeyboardWindow)
+                    } else {
+                        adapter.refreshWithOffset(it)
+                        candidateLayout.resetPosition()
+                    }
                 }
             }
         candidatesSubmitJob =
@@ -124,23 +128,11 @@ abstract class BaseUnrolledCandidateWindow(
         }
     }
 
-    private fun updateCandidatesWithOffset(offset: Int) {
-        val candidates = compactCandidate.adapter.items
-        if (candidates.isEmpty()) {
-            windowManager.attachWindow(KeyboardWindow)
-        } else {
-            adapter.refreshWithOffset(offset)
-            lifecycleCoroutineScope.launch(Dispatchers.Main) {
-                candidateLayout.resetPosition()
-            }
-        }
-    }
-
     override fun onDetached() {
         bar.unrollButtonStateMachine.push(
             UnrollButtonStateMachine.TransitionEvent.UnrolledCandidatesDetached,
             UnrollButtonStateMachine.BooleanKey.UnrolledCandidatesEmpty to
-                (adapter.offset == 0),
+                (compactCandidate.adapter.itemCount == adapter.offset),
         )
         offsetJob?.cancel()
         candidatesSubmitJob?.cancel()


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes # N/A

#### Feature
Describe features of this pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

