### PR TITLE
fix(keyboard): resolve key press sound effect not working on some dev…

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
@@ -46,7 +46,6 @@ import com.osfans.trime.daemon.RimeSession
 import com.osfans.trime.data.prefs.AppPrefs
 import com.osfans.trime.data.prefs.PreferenceDelegate
 import com.osfans.trime.data.prefs.PreferenceDelegateProvider
-import com.osfans.trime.data.soundeffect.SoundEffectManager
 import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.Theme
 import com.osfans.trime.data.theme.ThemeManager
@@ -179,7 +178,6 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
         ThemeManager.init(resources.configuration)
         ThemeManager.addOnChangedListener(onThemeChangeListener)
         ColorManager.addOnChangedListener(onColorChangeListener)
-        SoundEffectManager.init()
         InputFeedbackManager.init(this)
         registerReceiver()
         super.onCreate()

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/InputFeedbackManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/InputFeedbackManager.kt
@@ -49,7 +49,6 @@ object InputFeedbackManager {
                             .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
                             .build(),
                     ).build()
-            cacheSoundId()
         } catch (e: Exception) {
             Timber.e(e, "Error on initializing InputFeedbackManager")
         }
@@ -66,6 +65,9 @@ object InputFeedbackManager {
     }
 
     fun startInput() {
+        if (SoundEffectManager.activeSoundEffect == null) {
+            SoundEffectManager.init()
+        }
         cacheSoundId()
     }
 

--- a/app/src/main/java/com/osfans/trime/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/osfans/trime/ui/main/MainActivity.kt
@@ -30,8 +30,10 @@ import com.osfans.trime.BuildConfig
 import com.osfans.trime.R
 import com.osfans.trime.daemon.launchOnReady
 import com.osfans.trime.data.prefs.AppPrefs
+import com.osfans.trime.data.soundeffect.SoundEffectManager
 import com.osfans.trime.databinding.ActivityMainBinding
 import com.osfans.trime.ui.setup.SetupActivity
+import com.osfans.trime.util.isStorageAvailable
 import com.osfans.trime.util.item
 import com.osfans.trime.util.parcelable
 import com.osfans.trime.util.startActivity
@@ -171,6 +173,13 @@ class MainActivity : AppCompatActivity() {
         if (viewModel.restartBackgroundSyncWork.value == true) {
             viewModel.restartBackgroundSyncWork.value = false
             BackgroundSyncWork.forceStart(this)
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (isStorageAvailable()) {
+            SoundEffectManager.init()
         }
     }
 


### PR DESCRIPTION
…ices after reboot and no sound effect selected in settings page

Target device: vivo OS 14

In PR #1815 and #1837, attempts were made to delay the initialization timing as much as possible, but user feedback indicated these approaches were ineffective. After further investigation, the solution was found to be initializing the sound effect when the keyboard pops up, which successfully resolved the issue during testing.

This change ensures that key press sound effects work properly after device reboot on affected devices, particularly those running vivo OS 14, by initializing the sound system at the appropriate time when the keyboard becomes visible.

<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #
Fixes #

#### Feature
Describe features of this pull request

#### Code of conduct
- [ ] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [ ] `make sytle-lint`
- [ ] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [ ] `make debug`

#### Manually test
- [ ] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

