### PR TITLE
refactor(core): normalize key event forwarding from physical keyboard

### DIFF
--- a/app/src/main/java/com/osfans/trime/core/KeyModifier.kt
+++ b/app/src/main/java/com/osfans/trime/core/KeyModifier.kt
@@ -89,15 +89,30 @@ value class KeyModifiers(
         fun of(v: Int) = KeyModifiers(v.toUInt())
 
         fun fromKeyEvent(event: KeyEvent): KeyModifiers {
+            val isRelease = event.action == KeyEvent.ACTION_UP
+            // drop modifier state when using combination keys to input number/symbol on some phones
+            // because rime doesn't recognize selection key with modifiers (eg. Alt+Q for 1)
+            // in which case event.getNumber().toInt() == event.getUnicodeChar()
+            // ... but some keys can have event.getNumber() return 0, need to check displayLabel as well
+            val unicode = event.unicodeChar
+            // skip ' ', because it would produce same unicodeChar regardless of the modifier
+            if (unicode != 0 && unicode != ' '.code) {
+                val char = unicode.toChar()
+                if (char == event.number || event.displayLabel.uppercaseChar() != char.uppercaseChar()) {
+                    return if (isRelease) Release else Empty
+                }
+            }
             var states = KeyModifier.None.modifier
             event.apply {
+                // we just need to make rime care about following uncommented
+                // modifier states when forwarding physical keyboard event
                 if (isAltPressed) states += KeyModifier.Alt
                 if (isCtrlPressed) states += KeyModifier.Control
                 if (isShiftPressed) states += KeyModifier.Shift
                 if (isCapsLockOn) states += KeyModifier.Lock
-                if (isNumLockOn) states += KeyModifier.Mod2 // NumLock
-                if (isMetaPressed) states += KeyModifier.Meta
-                if (action == KeyEvent.ACTION_UP) states += KeyModifier.Release
+//                if (isNumLockOn) states += KeyModifier.Mod2 // NumLock
+//                if (isMetaPressed) states += KeyModifier.Meta
+                if (isRelease) states += KeyModifier.Release
             }
             return KeyModifiers(states)
         }

--- a/app/src/main/java/com/osfans/trime/core/KeyValue.kt
+++ b/app/src/main/java/com/osfans/trime/core/KeyValue.kt
@@ -5,6 +5,7 @@
 
 package com.osfans.trime.core
 
+import android.view.KeyCharacterMap
 import android.view.KeyEvent
 
 @JvmInline
@@ -16,6 +17,21 @@ value class KeyValue(
     override fun toString() = "0x" + value.toString(16).padStart(4, '0')
 
     companion object {
-        fun fromKeyEvent(event: KeyEvent) = KeyValue(RimeKeyMapping.keyCodeToVal(event.keyCode))
+        fun fromKeyEvent(event: KeyEvent): KeyValue {
+            val charCode = event.unicodeChar
+            // try charCode first, allow upper and lower case characters generating different KeyValue
+            if (charCode != 0 &&
+                // skip \t, because it's charCode is different from KeyValue
+                charCode != '\t'.code &&
+                // skip \n, because rime wants \r for return
+                charCode != '\n'.code &&
+                // skip Android's private-use character
+                charCode != KeyCharacterMap.HEX_INPUT.code &&
+                charCode != KeyCharacterMap.PICKER_DIALOG_INPUT.code
+            ) {
+                return KeyValue(charCode)
+            }
+            return KeyValue(RimeKeyMapping.keyCodeToVal(event.keyCode))
+        }
     }
 }

--- a/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
@@ -35,7 +35,6 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.inputmethod.EditorInfoCompat
 import androidx.core.view.updateLayoutParams
 import androidx.lifecycle.lifecycleScope
-import com.osfans.trime.core.KeyModifier
 import com.osfans.trime.core.KeyModifiers
 import com.osfans.trime.core.KeyValue
 import com.osfans.trime.core.RimeApi
@@ -668,27 +667,9 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
     }
 
     private fun forwardKeyEvent(event: KeyEvent): Boolean {
-        val up = event.action == KeyEvent.ACTION_UP
-        var modifiers = KeyModifiers.fromKeyEvent(event)
-        // Filter out NumLock for non-numpad keys to fix scrcpy issue
-        // where NumLock is incorrectly sent with keys like space and backspace
-        if (event.keyCode !in KeyEvent.KEYCODE_NUMPAD_0..KeyEvent.KEYCODE_NUMPAD_EQUALS) {
-            modifiers = KeyModifiers(modifiers.modifiers and KeyModifier.Mod2.modifier.inv())
-        }
-        val charCode = event.unicodeChar
-        if (charCode > 0 && charCode != '\t'.code && charCode != '\n'.code && charCode != ' '.code) {
-            // drop modifier state when using combination keys to input number/symbol on some phones
-            // because rime doesn't recognize selection key with modifiers (eg. Alt+Q for 1)
-            // in which case event.getNumber().toInt() == event.getUnicodeChar()
-            val empty = if (up) KeyModifiers.Release else KeyModifiers.Empty
-            val m = if (event.number.code == charCode) empty else modifiers
-            postRimeJob {
-                processKey(charCode, m.modifiers, isVirtual = false)
-            }
-            return true
-        }
         val keyVal = KeyValue.fromKeyEvent(event)
         if (keyVal.value != RimeKeyMapping.RimeKey_VoidSymbol) {
+            val modifiers = KeyModifiers.fromKeyEvent(event)
             postRimeJob {
                 processKey(keyVal, modifiers, isVirtual = false)
             }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #1744 (maybe)

#### Feature
Describe features of this pull request

Make rime just care about Alt, Ctrl, Shift, CapsLock and Release modifier state when forwarding physical keyboard event, so we can cancel the rough filtering of NumLock in eb70fe4e2aeda1f2039164d459bf323712a53795.

This may fix the root cause that some key is not often working when using physical keyboard.

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

