### PR TITLE
fix: candidates usually couldn't be unrolled in landscape mode

### DIFF
--- a/app/src/main/java/com/osfans/trime/core/Rime.kt
+++ b/app/src/main/java/com/osfans/trime/core/Rime.kt
@@ -247,11 +247,8 @@ class Rime :
         if (getRimeOption("paging_mode")) {
             handleRimeMessage(6, arrayOf(context.menu))
         } else {
-            val candidates = getRimeCandidates(0, 16)
-            handleRimeMessage(
-                8,
-                arrayOf(candidates),
-            )
+            val bulk = getRimeBulkCandidates()
+            handleRimeMessage(8, bulk)
         }
         handleRimeMessage(7, arrayOf(getRimeStatus()))
     }
@@ -466,6 +463,9 @@ class Rime :
             startIndex: Int,
             limit: Int,
         ): Array<CandidateItem>
+
+        @JvmStatic
+        external fun getRimeBulkCandidates(): Array<Any>
 
         @JvmStatic
         fun handleRimeMessage(

--- a/app/src/main/java/com/osfans/trime/core/RimeMessage.kt
+++ b/app/src/main/java/com/osfans/trime/core/RimeMessage.kt
@@ -92,27 +92,29 @@ sealed class RimeMessage<T>(
     }
 
     data class CandidateListMessage(
-        override val data: Array<CandidateItem>,
-    ) : RimeMessage<Array<CandidateItem>>(data) {
+        override val data: Data,
+    ) : RimeMessage<CandidateListMessage.Data>(data) {
 
         override val messageType = MessageType.Candidate
 
-        override fun equals(other: Any?): Boolean {
-            if (this === other) return true
-            if (javaClass != other?.javaClass) return false
+        data class Data(val total: Int = -1, val candidates: Array<CandidateItem> = arrayOf()) {
+            override fun equals(other: Any?): Boolean {
+                if (this === other) return true
+                if (javaClass != other?.javaClass) return false
 
-            other as CandidateListMessage
+                other as Data
 
-            if (!data.contentEquals(other.data)) return false
-            if (messageType != other.messageType) return false
+                if (total != other.total) return false
+                if (!candidates.contentEquals(other.candidates)) return false
 
-            return true
-        }
+                return true
+            }
 
-        override fun hashCode(): Int {
-            var result = data.contentHashCode()
-            result = 31 * result + messageType.hashCode()
-            return result
+            override fun hashCode(): Int {
+                var result = total
+                result = 31 * result + candidates.contentHashCode()
+                return result
+            }
         }
     }
 
@@ -175,7 +177,12 @@ sealed class RimeMessage<T>(
             MessageType.Status ->
                 StatusMessage(params[0] as RimeProto.Status)
             MessageType.Candidate ->
-                CandidateListMessage(params[0] as Array<CandidateItem>)
+                CandidateListMessage(
+                    CandidateListMessage.Data(
+                        params[0] as Int,
+                        params[1] as Array<CandidateItem>,
+                    ),
+                )
             MessageType.Key ->
                 KeyMessage(
                     KeyMessage.Data(

--- a/app/src/main/java/com/osfans/trime/ime/bar/QuickBar.kt
+++ b/app/src/main/java/com/osfans/trime/ime/bar/QuickBar.kt
@@ -182,10 +182,10 @@ class QuickBar(
         candidateUi.unrollButton.visibility = if (enabled) View.VISIBLE else View.INVISIBLE
     }
 
-    override fun onCandidateListUpdate(candidates: Array<CandidateItem>) {
+    override fun onCandidateListUpdate(data: RimeMessage.CandidateListMessage.Data) {
         barStateMachine.push(
             QuickBarStateMachine.TransitionEvent.CandidatesUpdated,
-            QuickBarStateMachine.BooleanKey.CandidateEmpty to candidates.isEmpty(),
+            QuickBarStateMachine.BooleanKey.CandidateEmpty to data.candidates.isEmpty(),
         )
     }
 

--- a/app/src/main/java/com/osfans/trime/ime/broadcast/InputBroadcastReceiver.kt
+++ b/app/src/main/java/com/osfans/trime/ime/broadcast/InputBroadcastReceiver.kt
@@ -25,7 +25,7 @@ interface InputBroadcastReceiver {
 
     fun onRimeOptionUpdated(value: RimeMessage.OptionMessage.Data) {}
 
-    fun onCandidateListUpdate(candidates: Array<CandidateItem>) {}
+    fun onCandidateListUpdate(data: RimeMessage.CandidateListMessage.Data) {}
 
     fun onCompositionUpdate(data: RimeProto.Context.Composition) {}
 

--- a/app/src/main/java/com/osfans/trime/ime/broadcast/InputBroadcaster.kt
+++ b/app/src/main/java/com/osfans/trime/ime/broadcast/InputBroadcaster.kt
@@ -58,8 +58,8 @@ class InputBroadcaster : InputBroadcastReceiver {
         receivers.forEach { it.onRimeOptionUpdated(value) }
     }
 
-    override fun onCandidateListUpdate(candidates: Array<CandidateItem>) {
-        receivers.forEach { it.onCandidateListUpdate(candidates) }
+    override fun onCandidateListUpdate(data: RimeMessage.CandidateListMessage.Data) {
+        receivers.forEach { it.onCandidateListUpdate(data) }
     }
 
     override fun onCompositionUpdate(data: RimeProto.Context.Composition) {

--- a/app/src/main/java/com/osfans/trime/ime/candidates/compact/CompactCandidateModule.kt
+++ b/app/src/main/java/com/osfans/trime/ime/candidates/compact/CompactCandidateModule.kt
@@ -18,6 +18,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.android.flexbox.FlexboxLayoutManager
 import com.osfans.trime.R
 import com.osfans.trime.core.CandidateItem
+import com.osfans.trime.core.RimeMessage
 import com.osfans.trime.daemon.RimeSession
 import com.osfans.trime.daemon.launchOnReady
 import com.osfans.trime.data.theme.ColorManager
@@ -57,7 +58,7 @@ class CompactCandidateModule(
         bar.unrollButtonStateMachine.push(
             UnrollButtonStateMachine.TransitionEvent.UnrolledCandidatesUpdated,
             UnrollButtonStateMachine.BooleanKey.UnrolledCandidatesEmpty to
-                (adapter.itemCount == childCount),
+                (adapter.total == childCount),
         )
     }
 
@@ -105,10 +106,11 @@ class CompactCandidateModule(
         }
     }
 
-    override fun onCandidateListUpdate(candidates: Array<CandidateItem>) {
+    override fun onCandidateListUpdate(data: RimeMessage.CandidateListMessage.Data) {
+        val (total, candidates) = data
         val menu = rime.run { menuCached }
         val highlightedIndex = menu.run { highlightedCandidateIndex + pageSize * pageNumber }
-        adapter.updateCandidates(candidates, highlightedIndex)
+        adapter.updateCandidates(candidates, total, highlightedIndex)
         if (candidates.isEmpty()) {
             refreshUnrolled(0)
         }

--- a/app/src/main/java/com/osfans/trime/ime/candidates/compact/CompactCandidateViewAdapter.kt
+++ b/app/src/main/java/com/osfans/trime/ime/candidates/compact/CompactCandidateViewAdapter.kt
@@ -28,14 +28,19 @@ open class CompactCandidateViewAdapter(
 
     override fun getItemId(position: Int): Long = items.getOrNull(position).hashCode().toLong()
 
+    var total: Int = -1
+        private set
+
     var highlightedIdx: Int = -1
         private set
 
     fun updateCandidates(
         data: Array<CandidateItem>,
+        total: Int,
         highlightedIndex: Int,
     ) {
         super.submitList(data.toList())
+        this.total = total
         this.highlightedIdx = highlightedIndex
     }
 

--- a/app/src/main/java/com/osfans/trime/ime/candidates/unrolled/CandidatesPagingSource.kt
+++ b/app/src/main/java/com/osfans/trime/ime/candidates/unrolled/CandidatesPagingSource.kt
@@ -13,6 +13,7 @@ import timber.log.Timber
 
 class CandidatesPagingSource(
     val rime: RimeSession,
+    val total: Int,
     val offset: Int,
 ) : PagingSource<Int, CandidateItem>() {
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, CandidateItem> {
@@ -25,7 +26,11 @@ class CandidatesPagingSource(
                 getCandidates(startIndex, pageSize)
             }
         val prevKey = if (startIndex >= pageSize) startIndex - pageSize else null
-        val nextKey = if (candidates.size < pageSize) null else startIndex + pageSize
+        val nextKey = if (total > 0) {
+            if (startIndex + pageSize + 1 >= total) null else startIndex + pageSize
+        } else {
+            if (candidates.size < pageSize) null else startIndex + pageSize
+        }
         return LoadResult.Page(candidates.toList(), prevKey, nextKey)
     }
 

--- a/app/src/main/java/com/osfans/trime/ime/candidates/unrolled/window/BaseUnrolledCandidateWindow.kt
+++ b/app/src/main/java/com/osfans/trime/ime/candidates/unrolled/window/BaseUnrolledCandidateWindow.kt
@@ -32,6 +32,7 @@ import com.osfans.trime.ime.keyboard.KeyboardWindow
 import com.osfans.trime.ime.window.BoardWindow
 import com.osfans.trime.ime.window.BoardWindowManager
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import splitties.dimensions.dp
 import kotlin.math.max
@@ -86,6 +87,7 @@ abstract class BaseUnrolledCandidateWindow(
             pagingSourceFactory = {
                 CandidatesPagingSource(
                     rime,
+                    total = compactCandidate.adapter.total,
                     offset = adapter.offset,
                 )
             },
@@ -103,14 +105,14 @@ abstract class BaseUnrolledCandidateWindow(
                     if (it <= 0) {
                         windowManager.attachWindow(KeyboardWindow)
                     } else {
-                        adapter.refreshWithOffset(it)
                         candidateLayout.resetPosition()
+                        adapter.refreshWithOffset(it)
                     }
                 }
             }
         candidatesSubmitJob =
             lifecycleCoroutineScope.launch {
-                candidatesPager.flow.collect {
+                candidatesPager.flow.collectLatest {
                     adapter.submitData(it)
                 }
             }
@@ -132,7 +134,7 @@ abstract class BaseUnrolledCandidateWindow(
         bar.unrollButtonStateMachine.push(
             UnrollButtonStateMachine.TransitionEvent.UnrolledCandidatesDetached,
             UnrollButtonStateMachine.BooleanKey.UnrolledCandidatesEmpty to
-                (compactCandidate.adapter.itemCount == adapter.offset),
+                (compactCandidate.adapter.total == adapter.offset),
         )
         offsetJob?.cancel()
         candidatesSubmitJob?.cancel()

--- a/app/src/main/java/com/osfans/trime/ime/core/InputView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/InputView.kt
@@ -316,7 +316,7 @@ class InputView(
             }
             is RimeMessage.CandidateListMessage -> {
                 val data = if (candidatesMode == PopupCandidatesMode.ALWAYS_SHOW) {
-                    emptyArray()
+                    RimeMessage.CandidateListMessage.Data()
                 } else {
                     it.data
                 }

--- a/app/src/main/jni/librime_jni/helper-types.h
+++ b/app/src/main/jni/librime_jni/helper-types.h
@@ -33,3 +33,5 @@ class CandidateItem {
       : text(candidate.text),
         comment(candidate.comment ? candidate.comment : "") {}
 };
+
+using CandidateList = std::vector<CandidateItem>;

--- a/app/src/main/jni/librime_jni/rime_jni.cc
+++ b/app/src/main/jni/librime_jni/rime_jni.cc
@@ -146,8 +146,8 @@ class Rime {
     return rime->change_page(session(), backward);
   }
 
-  std::vector<CandidateItem> getCandidates(int startIndex, int limit) {
-    std::vector<CandidateItem> result;
+  CandidateList getCandidates(int startIndex, int limit) {
+    CandidateList result;
     result.reserve(limit);
     RimeCandidateListIterator iter{};
     if (rime->candidate_list_from_index(session(), &iter, startIndex)) {
@@ -161,6 +161,14 @@ class Rime {
       rime->candidate_list_end(&iter);
     }
     return std::move(result);
+  }
+
+  std::tuple<int, CandidateList> getBulkCandidates() {
+    constexpr int limit = 16;
+    auto list = getCandidates(0, limit);
+    // use -1 to indicate it's not sure how many candidates now
+    auto size = list.size() < limit ? list.size() : -1;
+    return std::make_tuple(size, std::move(list));
   }
 
   void exit() {
@@ -396,4 +404,18 @@ Java_com_osfans_trime_core_Rime_getRimeCandidates(JNIEnv *env, jclass clazz,
                                                   jint limit) {
   return rimeCandidateListToJObjectArray(
       env, Rime::Instance().getCandidates(start_index, limit));
+}
+
+extern "C" JNIEXPORT jobjectArray JNICALL
+Java_com_osfans_trime_core_Rime_getRimeBulkCandidates(JNIEnv *env,
+                                                      jclass clazz) {
+  auto [size, list] = Rime::Instance().getBulkCandidates();
+  auto jSize = JRef(
+      env, env->NewObject(GlobalRef->Integer, GlobalRef->IntegerInit, size));
+  auto jList =
+      JRef<jobjectArray>(env, rimeCandidateListToJObjectArray(env, list));
+  auto params = env->NewObjectArray(2, GlobalRef->Object, nullptr);
+  env->SetObjectArrayElement(params, 0, jSize);
+  env->SetObjectArrayElement(params, 1, jList);
+  return params;
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes # N/A

#### Feature
Describe features of this pull request

Rime cannot determine the total size of candidates when getting bulk unless reach the last page, so -1 is used to indicate this situation, unless the last page is reached.

- Restore the data class type of CandidateListMessage
- Add a JNI method to get bulk candidates

Ref: https://github.com/fcitx5-android/fcitx5-android/blob/63735fb42f7b905545f1975aea3f0bff38907c8d/app/src/main/cpp/androidfrontend/androidfrontend.cpp#L75-L104

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

