### PR TITLE
feat: enable highlight effect for unrolled candidates

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/bar/QuickBar.kt
+++ b/app/src/main/java/com/osfans/trime/ime/bar/QuickBar.kt
@@ -178,6 +178,13 @@ class QuickBar(
     val unrollButtonStateMachine =
         UnrollButtonStateMachine.new {
             when (it) {
+                UnrollButtonStateMachine.State.AboutToAttachWindow -> {
+                    setUnrollButtonToDetach()
+                    setUnrollButtonEnabled(true)
+                    windowManager.attachWindow(
+                        FlexboxUnrolledCandidateWindow(context, service, rime, theme, this, windowManager, candidate),
+                    )
+                }
                 UnrollButtonStateMachine.State.ClickToAttachWindow -> {
                     setUnrollButtonToAttach()
                     setUnrollButtonEnabled(true)
@@ -193,7 +200,7 @@ class QuickBar(
         }
 
     private fun setUnrollButtonToAttach() {
-        candidateUi.unrollButton.setOnClickListener { view ->
+        candidateUi.unrollButton.setOnClickListener {
             windowManager.attachWindow(
                 FlexboxUnrolledCandidateWindow(context, service, rime, theme, this, windowManager, candidate),
             )
@@ -202,7 +209,7 @@ class QuickBar(
     }
 
     private fun setUnrollButtonToDetach() {
-        candidateUi.unrollButton.setOnClickListener { view ->
+        candidateUi.unrollButton.setOnClickListener {
             windowManager.attachWindow(KeyboardWindow)
         }
         candidateUi.unrollButton.setIcon(R.drawable.ic_baseline_expand_less_24)

--- a/app/src/main/java/com/osfans/trime/ime/bar/UnrollButtonStateMachine.kt
+++ b/app/src/main/java/com/osfans/trime/ime/bar/UnrollButtonStateMachine.kt
@@ -5,6 +5,8 @@
 package com.osfans.trime.ime.bar
 
 import com.osfans.trime.ime.bar.UnrollButtonStateMachine.BooleanKey.UnrolledCandidatesEmpty
+import com.osfans.trime.ime.bar.UnrollButtonStateMachine.BooleanKey.UnrolledCandidatesHighlighted
+import com.osfans.trime.ime.bar.UnrollButtonStateMachine.State.AboutToAttachWindow
 import com.osfans.trime.ime.bar.UnrollButtonStateMachine.State.ClickToAttachWindow
 import com.osfans.trime.ime.bar.UnrollButtonStateMachine.State.ClickToDetachWindow
 import com.osfans.trime.ime.bar.UnrollButtonStateMachine.State.Hidden
@@ -14,6 +16,7 @@ import com.osfans.trime.util.TransitionBuildBlock
 
 object UnrollButtonStateMachine {
     enum class State {
+        AboutToAttachWindow,
         ClickToAttachWindow,
         ClickToDetachWindow,
         Hidden,
@@ -21,6 +24,7 @@ object UnrollButtonStateMachine {
 
     enum class BooleanKey : EventStateMachine.BooleanStateKey {
         UnrolledCandidatesEmpty,
+        UnrolledCandidatesHighlighted,
     }
 
     enum class TransitionEvent(
@@ -29,9 +33,11 @@ object UnrollButtonStateMachine {
         UnrolledCandidatesUpdated({
             from(Hidden) transitTo ClickToAttachWindow on (UnrolledCandidatesEmpty to false)
             from(ClickToAttachWindow) transitTo Hidden on (UnrolledCandidatesEmpty to true)
+            from(ClickToAttachWindow) transitTo AboutToAttachWindow on (UnrolledCandidatesHighlighted to true)
         }),
         UnrolledCandidatesAttached({
             from(ClickToAttachWindow) transitTo ClickToDetachWindow
+            from(AboutToAttachWindow) transitTo ClickToDetachWindow
         }),
         UnrolledCandidatesDetached({
             from(ClickToDetachWindow) transitTo Hidden on (UnrolledCandidatesEmpty to true)

--- a/app/src/main/java/com/osfans/trime/ime/candidates/CandidateItemUi.kt
+++ b/app/src/main/java/com/osfans/trime/ime/candidates/CandidateItemUi.kt
@@ -4,6 +4,7 @@
 
 package com.osfans.trime.ime.candidates
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.drawable.ColorDrawable
 import android.view.View
@@ -122,19 +123,20 @@ class CandidateItemUi(
         )
     }
 
+    @SuppressLint("UseKtx")
     fun update(
         item: CandidateItem,
-        isHighlighted: Boolean,
+        highlighted: Boolean,
     ) {
-        val tColor = if (isHighlighted) hlTextColor else textColor
-        val cColor = if (isHighlighted) hlCommentColor else commentColor
+        val tColor = if (highlighted) hlTextColor else textColor
+        val cColor = if (highlighted) hlCommentColor else commentColor
         text.text = item.text
         text.setTextColor(tColor)
         comment.text = if (theme.generalStyle.commentOnTop) item.comment else " ${item.comment}"
         comment.setTextColor(cColor)
         comment.isGone = item.comment.isEmpty()
         root.background =
-            if (isHighlighted) {
+            if (highlighted) {
                 ColorDrawable(hlBackColor)
             } else {
                 pressHighlightDrawable(hlBackColor)

--- a/app/src/main/java/com/osfans/trime/ime/candidates/compact/CompactCandidateModule.kt
+++ b/app/src/main/java/com/osfans/trime/ime/candidates/compact/CompactCandidateModule.kt
@@ -62,11 +62,16 @@ class CompactCandidateModule(
             UnrollButtonStateMachine.BooleanKey.UnrolledCandidatesEmpty to
                 (adapter.total == childCount),
         )
+        bar.unrollButtonStateMachine.push(
+            UnrollButtonStateMachine.TransitionEvent.UnrolledCandidatesUpdated,
+            UnrollButtonStateMachine.BooleanKey.UnrolledCandidatesHighlighted to
+                (adapter.highlightedIdx >= childCount),
+        )
     }
 
     val adapter by lazy {
         CompactCandidateViewAdapter(theme).apply {
-            setOnItemClickListener { _, view, position ->
+            setOnItemClickListener { _, _, position ->
                 rime.launchOnReady { it.selectCandidate(position, global = true) }
             }
             setOnItemLongClickListener { _, view, position ->

--- a/app/src/main/java/com/osfans/trime/ime/candidates/unrolled/PagingCandidateViewAdapter.kt
+++ b/app/src/main/java/com/osfans/trime/ime/candidates/unrolled/PagingCandidateViewAdapter.kt
@@ -34,8 +34,12 @@ open class PagingCandidateViewAdapter(
     var offset: Int = 0
         private set
 
-    fun refreshWithOffset(offset: Int) {
+    var highlightedIndex: Int = -1
+        private set
+
+    fun refreshWith(offset: Int, highlightedIndex: Int) {
         this.offset = offset
+        this.highlightedIndex = highlightedIndex
         refresh()
     }
 
@@ -49,9 +53,11 @@ open class PagingCandidateViewAdapter(
         position: Int,
     ) {
         val item = getItem(position) ?: return
-        holder.ui.update(item, false)
+        val idx = position + offset
+        val highlighted = idx == highlightedIndex
+        holder.ui.update(item, highlighted)
         holder.text = item.text
         holder.comment = item.comment
-        holder.idx = position + offset
+        holder.idx = idx
     }
 }

--- a/app/src/main/java/com/osfans/trime/ime/candidates/unrolled/window/BaseUnrolledCandidateWindow.kt
+++ b/app/src/main/java/com/osfans/trime/ime/candidates/unrolled/window/BaseUnrolledCandidateWindow.kt
@@ -106,7 +106,10 @@ abstract class BaseUnrolledCandidateWindow(
                         windowManager.attachWindow(KeyboardWindow)
                     } else {
                         candidateLayout.resetPosition()
-                        adapter.refreshWithOffset(it)
+                        adapter.refreshWith(
+                            offset = it,
+                            highlightedIndex = compactCandidate.adapter.highlightedIdx,
+                        )
                     }
                 }
             }
@@ -120,7 +123,7 @@ abstract class BaseUnrolledCandidateWindow(
 
     fun bindCandidateUiViewHolder(holder: CandidateViewHolder) {
         holder.itemView.run {
-            setOnClickListener { view ->
+            setOnClickListener { _ ->
                 rime.launchOnReady { it.selectCandidate(holder.idx, global = true) }
             }
             setOnLongClickListener { view ->


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #1794 (a tweak for that)

#### Feature
Describe features of this pull request

And when the highlighted index is bigger than the compact candidates child count, the unrolled candidates window will be attached automatically.

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

