### PR TITLE
fix(provider): crash on creating RimeDataProvider onCreate fails

### DIFF
--- a/app/src/main/java/com/osfans/trime/provider/RimeDataProvider.kt
+++ b/app/src/main/java/com/osfans/trime/provider/RimeDataProvider.kt
@@ -72,7 +72,7 @@ class RimeDataProvider : DocumentsProvider() {
     private fun fileFromDocId(docId: String) = File(docIdPrefix, docId)
 
     override fun onCreate(): Boolean {
-        baseDir = context!!.getExternalFilesDir(null)!!
+        baseDir = context!!.getExternalFilesDir(null) ?: return false
         docIdPrefix = "${baseDir.parent}${File.separator}"
         textFilePaths = Array(TEXT_FILES.size) { baseDir.resolve(TEXT_FILES[it]).absolutePath }
         return true


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #1889 

#### Feature
Describe features of this pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

