### PR TITLE
fix: first prediction candidate always be force selected

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
@@ -420,15 +420,19 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
         updateIndex: Int,
     ) {
         if (newSelStart != newSelEnd) return
-        if (candidatesStart == candidatesEnd) {
-            postRimeJob {
-                if (statusCached.isComposing) {
-                    Timber.d("handleCursorUpdate: commit composition")
-                    commitComposition()
-                }
-            }
-            return
-        }
+        // TODO: here is originally to fix some problems when user input is
+        //  too fast, but if users enable prediction, the composing can be
+        //  empty while candidates is not empty, leading to new issue caused
+        //  by here.
+//        if (candidatesStart == candidatesEnd) {
+//            postRimeJob {
+//                if (statusCached.isComposing) {
+//                    Timber.d("handleCursorUpdate: commit composition")
+//                    commitComposition()
+//                }
+//            }
+//            return
+//        }
         if (newSelStart in candidatesStart..candidatesEnd) {
             val position = newSelStart - candidatesStart
             if (position != composingText.length) {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes # N/A

#### Feature
Describe features of this pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

