### PR TITLE
refactor: remove unreachable composition clearing code

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
@@ -420,15 +420,7 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
         updateIndex: Int,
     ) {
         if (newSelStart != newSelEnd) return
-        if (candidatesStart == candidatesEnd) {
-            postRimeJob {
-                if (composingText.isNotEmpty() && (statusCached.isComposing || hasMenu)) {
-                    Timber.d("handleCursorUpdate: clear composition")
-                    clearComposition()
-                }
-            }
-            return
-        }
+        if (candidatesStart == candidatesEnd) return
         if (newSelStart in candidatesStart..candidatesEnd) {
             val position = newSelStart - candidatesStart
             if (position != composingText.length) {
@@ -440,10 +432,6 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
             }
         } else {
             Timber.d("handleCursorUpdate: clear composition")
-            if (!rime.run { statusCached.isComposing }) {
-                composingText = ""
-                currentInputConnection?.finishComposingText()
-            }
             postRimeJob {
                 clearComposition()
             }
@@ -574,10 +562,9 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
 
     fun commitText(text: String) {
         val ic = currentInputConnection ?: return
-        val isComposing = rime.run { statusCached.isComposing }
 
         // when composing text equals commit content, finish composing text as-is
-        if (composingText == text && !isComposing) {
+        if (composingText.isNotEmpty() && composingText == text) {
             composingText = ""
             ic.finishComposingText()
             return


### PR DESCRIPTION
Remove two pieces of meaningless code in handleCursorUpdate:

1. The first code block with condition `composingText.isNotEmpty() && (statusCached.isComposing || hasMenu)` is effectively unreachable. Even if the condition could be satisfied in rare cases, clearing composition at this point would inevitably cause bugs, so it must remain unreachable.

2. Calling finishComposingText() when `!statusCached.isComposing` is nonsensical, as it attempts to finish composing when there is no composing state.

<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #
Fixes #

#### Feature
Describe features of this pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

