### PR TITLE
refactor: send KEYCODE_ENTER instead of commit "\n" when pressing enter on virtual keyboard

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
@@ -298,13 +298,10 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
 
     private fun handleReturnKey() {
         currentInputEditorInfo.run {
-            if (inputType and InputType.TYPE_MASK_CLASS == InputType.TYPE_NULL) {
+            if (inputType and InputType.TYPE_MASK_CLASS == InputType.TYPE_NULL ||
+                imeOptions.hasFlag(EditorInfo.IME_FLAG_NO_ENTER_ACTION)
+            ) {
                 sendDownUpKeyEvents(KeyEvent.KEYCODE_ENTER)
-                return
-            }
-            if (imeOptions.hasFlag(EditorInfo.IME_FLAG_NO_ENTER_ACTION)) {
-                val ic = currentInputConnection
-                ic?.commitText("\n", 1)
                 return
             }
             if (!actionLabel.isNullOrEmpty() && actionId != EditorInfo.IME_ACTION_UNSPECIFIED) {
@@ -312,7 +309,9 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
                 return
             }
             when (val action = imeOptions and EditorInfo.IME_MASK_ACTION) {
-                EditorInfo.IME_ACTION_UNSPECIFIED, EditorInfo.IME_ACTION_NONE -> currentInputConnection.commitText("\n", 1)
+                EditorInfo.IME_ACTION_UNSPECIFIED,
+                EditorInfo.IME_ACTION_NONE,
+                -> sendDownUpKeyEvents(KeyEvent.KEYCODE_ENTER)
                 else -> currentInputConnection.performEditorAction(action)
             }
         }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #1939 

#### Feature
Describe features of this pull request

Fix some misbehavior editors with non-empty IME_ACTION_* but also IME_FLAG_NO_ENTER_ACTION: just let the editor handle enter key itself

Ref: https://github.com/fcitx5-android/fcitx5-android/commit/61e10af132e858919c9749d181f8dd79c8f25f0b

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

