### PR TITLE
refactor: set essential cmake argument in Gradle script

### DIFF
--- a/app/src/main/jni/CMakeLists.txt
+++ b/app/src/main/jni/CMakeLists.txt
@@ -4,13 +4,10 @@
 
 cmake_minimum_required(VERSION 3.18.0)
 
-project(trime-lib VERSION 3.0.0)
+project(trime VERSION 3.0.0)
 
 # for reproducible build
 add_link_options("LINKER:--hash-style=gnu,--build-id=none")
-
-set(ANDROID_STL c++_shared)
-set(CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 

--- a/build-logic/convention/src/main/kotlin/NativeBaseConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/NativeBaseConventionPlugin.kt
@@ -13,6 +13,14 @@ open class NativeBaseConventionPlugin : Plugin<Project> {
         target.pluginManager.apply("com.android.application")
         target.extensions.configure(CommonExtension::class.java) {
             ndkVersion = target.ndkVersion
+            defaultConfig {
+                @Suppress("UnstableApiUsage")
+                externalNativeBuild {
+                    cmake {
+                        arguments("-DANDROID_STL=c++_static")
+                    }
+                }
+            }
             // Use prebuilt JNI library if the "app/prebuilt" exists
             //
             // Steps to generate the prebuilt directory:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #N/A

#### Feature
Describe features of this pull request

The settings in CMakeLists.txt doesn't take effect actually, so we need this migration. And we set ANDROID_STL as c++_static explicitly, since trime just build one `.so`.

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

