### PR TITLE
refactor: avoid recreating InputView on unnecessary Configuration changes

### DIFF
--- a/app/src/main/java/com/osfans/trime/TrimeApplication.kt
+++ b/app/src/main/java/com/osfans/trime/TrimeApplication.kt
@@ -8,6 +8,7 @@ package com.osfans.trime
 import android.app.Application
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.res.Configuration
 import android.os.Process
 import android.util.Log
 import androidx.core.content.ContextCompat
@@ -17,8 +18,10 @@ import com.osfans.trime.data.db.ClipboardHelper
 import com.osfans.trime.data.db.CollectionHelper
 import com.osfans.trime.data.prefs.AppPrefs
 import com.osfans.trime.data.soundeffect.SoundEffectManager
+import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.receiver.RimeIntentReceiver
 import com.osfans.trime.ui.main.LogActivity
+import com.osfans.trime.util.isNightMode
 import com.osfans.trime.worker.BackgroundSyncWork
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.MainScope
@@ -141,6 +144,15 @@ class TrimeApplication : Application() {
         } catch (e: Exception) {
             e.fillInStackTrace()
             return
+        }
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        try {
+            ColorManager.onSystemNightModeChange(newConfig.isNightMode())
+        } catch (e: Exception) {
+            Timber.w(e, "Something wrong on configuration changed")
         }
     }
 

--- a/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
@@ -6,9 +6,9 @@
 package com.osfans.trime.ime.core
 
 import android.annotation.SuppressLint
-import android.annotation.TargetApi
 import android.app.Dialog
 import android.content.IntentFilter
+import android.content.pm.ActivityInfo
 import android.content.res.Configuration
 import android.graphics.RectF
 import android.inputmethodservice.InputMethodService
@@ -54,7 +54,6 @@ import com.osfans.trime.receiver.RimeIntentReceiver
 import com.osfans.trime.util.any
 import com.osfans.trime.util.findSectionFrom
 import com.osfans.trime.util.forceShowSelf
-import com.osfans.trime.util.isNightMode
 import com.osfans.trime.util.monitorCursorAnchor
 import com.osfans.trime.util.styledFloat
 import kotlinx.coroutines.CoroutineScope
@@ -77,6 +76,7 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
     private val prefs = AppPrefs.defaultInstance()
     private lateinit var decorView: View
     private lateinit var contentView: FrameLayout
+    private lateinit var lastKnownConfig: Configuration
     private var inputView: InputView? = null
     private var candidatesView: CandidatesView? = null
     private val navBarManager = NavigationBarManager()
@@ -185,6 +185,7 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
         Timber.d("onCreate")
         decorView = window.window!!.decorView
         contentView = decorView.findViewById(android.R.id.content)
+        lastKnownConfig = Configuration(resources.configuration)
     }
 
     private fun handleRimeMessage(it: RimeMessage<*>) {
@@ -312,15 +313,26 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
                 EditorInfo.IME_ACTION_UNSPECIFIED,
                 EditorInfo.IME_ACTION_NONE,
                 -> sendDownUpKeyEvents(KeyEvent.KEYCODE_ENTER)
+
                 else -> currentInputConnection.performEditorAction(action)
             }
         }
     }
 
+    /**
+     * https://github.com/fcitx5-android/fcitx5-android/blob/fe3a618c8fd18842305d2f8ec2880fcc67ec1679/app/src/main/java/org/fcitx/fcitx5/android/input/FcitxInputMethodService.kt#L523-#L547
+     */
     override fun onConfigurationChanged(newConfig: Configuration) {
-        super.onConfigurationChanged(newConfig)
         postRimeJob { clearComposition() }
-        ColorManager.onSystemNightModeChange(newConfig.isNightMode())
+        val keyboardUiModeMask = ActivityInfo.CONFIG_KEYBOARD or
+            ActivityInfo.CONFIG_KEYBOARD_HIDDEN or
+            ActivityInfo.CONFIG_UI_MODE
+        val diff = lastKnownConfig.diff(newConfig)
+        Timber.d("onConfigurationChanged diff=$diff")
+        if (diff and keyboardUiModeMask != diff) {
+            super.onConfigurationChanged(newConfig)
+        }
+        lastKnownConfig.setTo(newConfig)
     }
 
     override fun onWindowShown() {
@@ -727,15 +739,14 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
     ): Boolean = forwardKeyEvent(event) || super.onKeyUp(keyCode, event)
 
     // Added in API level 14, deprecated in 29
+    // it's needed because editors still use it even on API 36
     @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
     override fun onViewClicked(focusChanged: Boolean) {
         super.onViewClicked(focusChanged)
-        if (Build.VERSION.SDK_INT < 34) {
-            inputDeviceManager.evaluateOnViewClicked(this)
-        }
+        inputDeviceManager.evaluateOnViewClicked(this)
     }
 
-    @TargetApi(34)
+    @RequiresApi(34)
     override fun onUpdateEditorToolType(toolType: Int) {
         super.onUpdateEditorToolType(toolType)
         inputDeviceManager.evaluateOnUpdateEditorToolType(toolType, this)


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes # N/A

#### Feature
Describe features of this pull request

Ref: https://github.com/fcitx5-android/fcitx5-android/blob/fe3a618c8fd18842305d2f8ec2880fcc67ec1679/app/src/main/java/org/fcitx/fcitx5/android/input/FcitxInputMethodService.kt#L523-#L547

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

