### PR TITLE
fix: add additional measures for navBar, tappable, mandatory, and system gestures when lifting keyboard.

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/core/BaseInputView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/BaseInputView.kt
@@ -66,6 +66,10 @@ abstract class BaseInputView(
         }
 
     protected fun getNavBarBottomInset(windowInsets: WindowInsets): Int {
+        if (navBarBackground != ThemePrefs.NavbarBackground.FULL) {
+            return 0
+        }
+
         val insets = WindowInsetsCompat.toWindowInsetsCompat(windowInsets)
 
         val nav = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom

--- a/app/src/main/java/com/osfans/trime/ime/core/BaseInputView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/BaseInputView.kt
@@ -66,27 +66,22 @@ abstract class BaseInputView(
         }
 
     protected fun getNavBarBottomInset(windowInsets: WindowInsets): Int {
-        if (navBarBackground != ThemePrefs.NavbarBackground.FULL) {
-            return 0
-        }
         val insets = WindowInsetsCompat.toWindowInsetsCompat(windowInsets)
-        val navBars = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
-        val mandatory = insets.getInsets(WindowInsetsCompat.Type.mandatorySystemGestures())
-        // If navBars is 0 but mandatory is non-zero, likely gesture nav - don't add inset
-        if (navBars.bottom == 0 && mandatory.bottom > 0) {
-            return 0
-        }
-        var insetsBottom = max(navBars.bottom, mandatory.bottom)
-        if (insetsBottom <= 0) {
-            val gestures = insets.getInsets(WindowInsetsCompat.Type.systemGestures())
-            val gesturesBottom = gestures.bottom
-            if (gesturesBottom > 0) {
-                insetsBottom = max(gesturesBottom, navBarFrameHeight)
-            }
-        }
-        return insetsBottom
-    }
 
+        val nav = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
+        val tappable = insets.getInsets(WindowInsetsCompat.Type.tappableElement()).bottom
+        val mandatory = insets.getInsets(WindowInsetsCompat.Type.mandatorySystemGestures()).bottom
+        val systemGestures = insets.getInsets(WindowInsetsCompat.Type.systemGestures()).bottom
+        val threshold = (resources.displayMetrics.density * 40).toInt()
+
+        return when {
+            nav > 0 -> nav
+            tappable > 0 -> tappable
+            mandatory > threshold -> mandatory
+            systemGestures > threshold -> systemGestures
+            else -> 0
+        }
+    }
     override fun onDetachedFromWindow() {
         handleMessages = false
         super.onDetachedFromWindow()

--- a/app/src/main/java/com/osfans/trime/ime/core/BaseInputView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/BaseInputView.kt
@@ -70,15 +70,16 @@ abstract class BaseInputView(
             return 0
         }
         val insets = WindowInsetsCompat.toWindowInsetsCompat(windowInsets)
-        // use navigation bar insets when available
         val navBars = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
-        // in case navigation bar insets goes wrong (eg. on LineageOS 21+ with gesture navigation)
-        // use mandatory system gesture insets
         val mandatory = insets.getInsets(WindowInsetsCompat.Type.mandatorySystemGestures())
+        // If navBars is 0 but mandatory is non-zero, likely gesture nav - don't add inset
+        if (navBars.bottom == 0 && mandatory.bottom > 0) {
+            return 0
+        }
         var insetsBottom = max(navBars.bottom, mandatory.bottom)
         if (insetsBottom <= 0) {
-            // check system gesture insets and fallback to navigation_bar_frame_height just in case
-            val gesturesBottom = insets.getInsets(WindowInsetsCompat.Type.systemGestures()).bottom
+            val gestures = insets.getInsets(WindowInsetsCompat.Type.systemGestures())
+            val gesturesBottom = gestures.bottom
             if (gesturesBottom > 0) {
                 insetsBottom = max(gesturesBottom, navBarFrameHeight)
             }

--- a/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
@@ -32,6 +32,7 @@ import android.widget.FrameLayout
 import androidx.annotation.Keep
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updateLayoutParams
 import androidx.lifecycle.lifecycleScope
@@ -455,23 +456,36 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
     override fun onComputeInsets(outInsets: Insets) {
         if (inputDeviceManager.isVirtualKeyboard) {
             inputView?.keyboardView?.getLocationInWindow(inputViewLocation)
+            val top = inputViewLocation[1]
             outInsets.apply {
-                contentTopInsets = inputViewLocation[1]
-                visibleTopInsets = inputViewLocation[1]
+                contentTopInsets = top
+                visibleTopInsets = top
                 touchableInsets = Insets.TOUCHABLE_INSETS_VISIBLE
             }
-        } else {
-            val insets = WindowInsetsCompat.toWindowInsetsCompat(decorView.rootWindowInsets)
-            val navBarHeight = insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0
-            val mandatoryHeight = insets?.getInsets(WindowInsetsCompat.Type.mandatorySystemGestures())?.bottom ?: 0
-            // If navBarHeight is 0 but mandatory is non-zero, likely gesture nav - don't add inset
-            val finalNavHeight = if (navBarHeight == 0 && mandatoryHeight > 0) 0 else maxOf(navBarHeight, mandatoryHeight)
-            val h = decorView.height - finalNavHeight
-            outInsets.apply {
-                contentTopInsets = h
-                visibleTopInsets = h
-                touchableInsets = Insets.TOUCHABLE_INSETS_VISIBLE
-            }
+            return
+        }
+        val insets = ViewCompat.getRootWindowInsets(decorView)
+        val navBarHeight =
+            insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0
+        val tappableHeight =
+            insets?.getInsets(WindowInsetsCompat.Type.tappableElement())?.bottom ?: 0
+        val mandatoryHeight =
+            insets?.getInsets(WindowInsetsCompat.Type.mandatorySystemGestures())?.bottom ?: 0
+        val systemGestureHeight =
+            insets?.getInsets(WindowInsetsCompat.Type.systemGestures())?.bottom ?: 0
+        val threshold = (decorView.resources.displayMetrics.density * 40).toInt()
+        val finalNavHeight = when {
+            navBarHeight > 0 -> navBarHeight
+            tappableHeight > 0 -> tappableHeight
+            mandatoryHeight > threshold -> mandatoryHeight
+            systemGestureHeight > threshold -> systemGestureHeight
+            else -> 0
+        }
+        val keyboardTop = decorView.height - finalNavHeight
+        outInsets.apply {
+            contentTopInsets = keyboardTop
+            visibleTopInsets = keyboardTop
+            touchableInsets = Insets.TOUCHABLE_INSETS_VISIBLE
         }
     }
 

--- a/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
@@ -31,8 +31,8 @@ import android.view.inputmethod.InlineSuggestionsResponse
 import android.widget.FrameLayout
 import androidx.annotation.Keep
 import androidx.annotation.RequiresApi
-import androidx.core.view.WindowInsetsCompat
 import androidx.core.content.ContextCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updateLayoutParams
 import androidx.lifecycle.lifecycleScope
 import com.osfans.trime.core.KeyModifiers

--- a/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
@@ -31,6 +31,7 @@ import android.view.inputmethod.InlineSuggestionsResponse
 import android.widget.FrameLayout
 import androidx.annotation.Keep
 import androidx.annotation.RequiresApi
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.content.ContextCompat
 import androidx.core.view.updateLayoutParams
 import androidx.lifecycle.lifecycleScope
@@ -449,8 +450,12 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
                 touchableInsets = Insets.TOUCHABLE_INSETS_VISIBLE
             }
         } else {
-            val n = decorView.findViewById<View>(android.R.id.navigationBarBackground)?.height ?: 0
-            val h = decorView.height - n
+            val insets = WindowInsetsCompat.toWindowInsetsCompat(decorView.rootWindowInsets)
+            val navBarHeight = insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0
+            val mandatoryHeight = insets?.getInsets(WindowInsetsCompat.Type.mandatorySystemGestures())?.bottom ?: 0
+            // If navBarHeight is 0 but mandatory is non-zero, likely gesture nav - don't add inset
+            val finalNavHeight = if (navBarHeight == 0 && mandatoryHeight > 0) 0 else maxOf(navBarHeight, mandatoryHeight)
+            val h = decorView.height - finalNavHeight
             outInsets.apply {
                 contentTopInsets = h
                 visibleTopInsets = h


### PR DESCRIPTION
This should solve problems in https://github.com/osfans/trime/discussions/1855#discussioncomment-15897614
and https://github.com/osfans/trime/issues/1936

navBar and tappable will be used to lift the keyboard, while mandatory and systemGestures will apply only when they are large enough.

Fix #1936
Fix #1855

