### PR TITLE
fix: add additional measures for navBar, tappable, mandatory, and system gestures when lifting keyboard.

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/core/BaseInputView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/BaseInputView.kt
@@ -69,24 +69,23 @@ abstract class BaseInputView(
         if (navBarBackground != ThemePrefs.NavbarBackground.FULL) {
             return 0
         }
-        val insets = WindowInsetsCompat.toWindowInsetsCompat(windowInsets)
-        val navBars = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
-        val mandatory = insets.getInsets(WindowInsetsCompat.Type.mandatorySystemGestures())
-        // If navBars is 0 but mandatory is non-zero, likely gesture nav - don't add inset
-        if (navBars.bottom == 0 && mandatory.bottom > 0) {
-            return 0
-        }
-        var insetsBottom = max(navBars.bottom, mandatory.bottom)
-        if (insetsBottom <= 0) {
-            val gestures = insets.getInsets(WindowInsetsCompat.Type.systemGestures())
-            val gesturesBottom = gestures.bottom
-            if (gesturesBottom > 0) {
-                insetsBottom = max(gesturesBottom, navBarFrameHeight)
-            }
-        }
-        return insetsBottom
-    }
 
+        val insets = WindowInsetsCompat.toWindowInsetsCompat(windowInsets)
+
+        val nav = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
+        val tappable = insets.getInsets(WindowInsetsCompat.Type.tappableElement()).bottom
+        val mandatory = insets.getInsets(WindowInsetsCompat.Type.mandatorySystemGestures()).bottom
+        val systemGestures = insets.getInsets(WindowInsetsCompat.Type.systemGestures()).bottom
+        val threshold = (resources.displayMetrics.density * 40).toInt()
+
+        return when {
+            nav > 0 -> nav
+            tappable > 0 -> tappable
+            mandatory > threshold -> mandatory
+            systemGestures > threshold -> systemGestures
+            else -> 0
+        }
+    }
     override fun onDetachedFromWindow() {
         handleMessages = false
         super.onDetachedFromWindow()

--- a/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
@@ -461,12 +461,8 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
                 touchableInsets = Insets.TOUCHABLE_INSETS_VISIBLE
             }
         } else {
-            val insets = WindowInsetsCompat.toWindowInsetsCompat(decorView.rootWindowInsets)
-            val navBarHeight = insets?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0
-            val mandatoryHeight = insets?.getInsets(WindowInsetsCompat.Type.mandatorySystemGestures())?.bottom ?: 0
-            // If navBarHeight is 0 but mandatory is non-zero, likely gesture nav - don't add inset
-            val finalNavHeight = if (navBarHeight == 0 && mandatoryHeight > 0) 0 else maxOf(navBarHeight, mandatoryHeight)
-            val h = decorView.height - finalNavHeight
+            val n = decorView.findViewById<View>(android.R.id.navigationBarBackground)?.height ?: 0
+            val h = decorView.height - n
             outInsets.apply {
                 contentTopInsets = h
                 visibleTopInsets = h


### PR DESCRIPTION
This should solve problems in https://github.com/osfans/trime/discussions/1855#discussioncomment-15897614
and https://github.com/osfans/trime/issues/1936

navBar and tappable will be used to lift the keyboard, while mandatory and systemGestures will apply only when they are large enough.

Also revert TrimeInputMethodService.kt changes to its original implementations to keep Android 5.0 compatibility.

Fix https://github.com/osfans/trime/issues/1936
Fix https://github.com/osfans/trime/discussions/1855
