### PR TITLE
fix: clear key pressed state when popup keyboard focus out of bounds

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyView.kt
@@ -103,9 +103,9 @@ class KeyView(
                     popup.listener.onPopupAction(triggerAction)
                     triggerAction.outAction?.let { action ->
                         keyboardActionListener.onAction(KeyAction(action))
-                        setPressedState(false)
                         dismissPopupPreview()
                     }
+                    setPressedState(false)
                 } else if (isRepeatable) {
                     key.getAction(KeyBehavior.CLICK)?.let { processKeyAction(it, KeyBehavior.CLICK) }
                 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #
Fixes #

#### Feature
Describe features of this pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

