### PR TITLE
fix(keyboard): resolve incorrect keyboard width after screen rotation on certain devices

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/Keyboard.kt
@@ -5,6 +5,7 @@
 
 package com.osfans.trime.ime.keyboard
 
+import android.content.Context
 import android.graphics.Point
 import android.os.Build
 import android.view.KeyEvent
@@ -13,7 +14,6 @@ import com.osfans.trime.data.prefs.AppPrefs
 import com.osfans.trime.data.theme.Theme
 import com.osfans.trime.data.theme.model.TextKeyboard
 import com.osfans.trime.ime.keyboard.KeyboardPrefs.isLandscapeMode
-import com.osfans.trime.util.appContext
 import splitties.bitflags.hasFlag
 import splitties.dimensions.dp
 import splitties.systemservices.windowManager
@@ -23,6 +23,7 @@ import kotlin.math.pow
 /** 從YAML中加載鍵盤配置，包含多個[按鍵][Key]。  */
 @Suppress("ktlint:standard:property-naming")
 class Keyboard(
+    private val context: Context,
     private val theme: Theme,
     selfConfig: TextKeyboard? = null,
 ) {
@@ -32,7 +33,7 @@ class Keyboard(
         intArrayOf(
             selfConfig?.horizontalGap ?: 0,
             theme.generalStyle.horizontalGap,
-        ).firstOrNull { it > 0 }?.let { appContext.dp(it) } ?: 0
+        ).firstOrNull { it > 0 }?.let { context.dp(it) } ?: 0
 
     /** 默認鍵寬  */
     private val keyWidth: Int = (allowedWidth * theme.generalStyle.keyWidth / 100).toInt()
@@ -49,7 +50,7 @@ class Keyboard(
         intArrayOf(
             selfConfig?.verticalGap ?: 0,
             theme.generalStyle.verticalGap,
-        ).firstOrNull { it > 0 }?.let { appContext.dp(it) } ?: 0
+        ).firstOrNull { it > 0 }?.let { context.dp(it) } ?: 0
 
     /** 默認按鍵圓角半徑  */
     val roundCorner: Float =
@@ -93,23 +94,30 @@ class Keyboard(
     private val allowedWidth: Int
         get() {
             val padding = theme.generalStyle.run {
-                if (appContext.isLandscapeMode()) keyboardPaddingLand else keyboardPadding
+                if (context.isLandscapeMode()) keyboardPaddingLand else keyboardPadding
             }
 
             val safeWidth = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                val windowMetrics = appContext.windowManager.currentWindowMetrics
+                val windowMetrics = context.windowManager.maximumWindowMetrics
                 val insets = windowMetrics.windowInsets.getInsetsIgnoringVisibility(
                     WindowInsets.Type.systemBars() or WindowInsets.Type.displayCutout(),
                 )
-                windowMetrics.bounds.width() - insets.left - insets.right
+                val displayWidth = context.resources.displayMetrics.widthPixels
+                val windowWidth = windowMetrics.bounds.width() - insets.left - insets.right
+                val isPortrait = displayWidth < context.resources.displayMetrics.heightPixels
+                if (isPortrait && windowWidth < displayWidth - context.dp(1)) {
+                    displayWidth
+                } else {
+                    windowWidth
+                }
             } else {
                 @Suppress("DEPRECATION")
                 val size = Point()
                 @Suppress("DEPRECATION")
-                appContext.windowManager.defaultDisplay.getSize(size)
+                context.windowManager.defaultDisplay.getSize(size)
                 size.x
             }
-            return safeWidth - 2 * appContext.dp(padding)
+            return safeWidth - 2 * context.dp(padding)
         }
 
     /** Keyboard default ascii mode  */
@@ -159,7 +167,7 @@ class Keyboard(
 
             val maxColumns = if (selfConfig.columns == -1) Int.MAX_VALUE else selfConfig.columns
 
-            val isSplit = appContext.isLandscapeMode() && landscapePercent > 0
+            val isSplit = context.isLandscapeMode() && landscapePercent > 0
             val splitRatio = if (isSplit) landscapePercent / 100f else 0f
 
             val oneWeightWidthPx =
@@ -333,20 +341,20 @@ class Keyboard(
 
     private fun getKeyboardHeightFromTheme(theme: Theme): Int {
         var keyboardHeight = theme.generalStyle.keyboardHeight
-        if (appContext.isLandscapeMode()) {
+        if (context.isLandscapeMode()) {
             val keyboardHeightLand = theme.generalStyle.keyboardHeightLand
             if (keyboardHeightLand > 0) keyboardHeight = keyboardHeightLand
         }
-        return appContext.dp(keyboardHeight)
+        return context.dp(keyboardHeight)
     }
 
     private fun getKeyboardHeightFromKeyboardConfig(textKeyboard: TextKeyboard): Int {
         var keyboardHeight = textKeyboard.keyboardHeight
-        if (appContext.isLandscapeMode()) {
+        if (context.isLandscapeMode()) {
             val keyboardHeightLand = textKeyboard.keyboardHeightLand
             if (keyboardHeightLand > 0) keyboardHeight = keyboardHeightLand
         }
-        return appContext.dp(keyboardHeight)
+        return context.dp(keyboardHeight)
     }
 
     fun setModifierKey(

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardWindow.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardWindow.kt
@@ -109,7 +109,7 @@ class KeyboardWindow :
         lastKeyboardId = target
 
         val config = selectKeyboardConfig(target)
-        val keyboard = currentKeyboard ?: Keyboard(theme, config)
+        val keyboard = currentKeyboard ?: Keyboard(context, theme, config)
         val view = currentKeyboardView ?: KeyboardView(context, theme, keyboard, popup, service, keyboardActionListener, enterKeyDisplay)
 
         if (currentKeyboard == null) {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->

#### Feature
- Replace appContext with injected service context — ensures displayMetrics reflects the current configuration when the IME view is recreated after rotation
- Add stale insets detection with fallback — compare computed windowWidth against raw displayMetrics.widthPixels ; if the difference exceeds a threshold (1dp) in portrait mode, fall back to displayMetrics.widthPixels as the reliable
- Use maximumWindowMetrics instead of currentWindowMetrics — provides the maximum available window area regardless of current window state

#### Code of conduct
- [ ] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [ ] `make sytle-lint`
- [ ] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [ ] `make debug`

#### Manually test
- Tested by 5 users , all confirmed resolved

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info
![Screenshot_2026-04-11-13-37-36-78_d575fd10b440f1adc203f4f6bca6eb00](https://github.com/user-attachments/assets/278af87e-f27f-4e4f-b3fe-7c2ab773087d)

