### PR TITLE
feat: remove preedit text highlighted back color

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/composition/PreeditUi.kt
+++ b/app/src/main/java/com/osfans/trime/ime/composition/PreeditUi.kt
@@ -7,7 +7,6 @@ package com.osfans.trime.ime.composition
 
 import android.content.Context
 import android.text.Spanned
-import android.text.style.BackgroundColorSpan
 import android.text.style.ForegroundColorSpan
 import android.view.MotionEvent
 import android.view.View
@@ -31,7 +30,6 @@ open class PreeditUi(
 ) : Ui {
     private val textColor = ColorManager.getColor("text_color")
     private val highlightTextColor = ColorManager.getColor("hilited_text_color")
-    private val highlightBackColor = ColorManager.getColor("hilited_back_color")
 
     val preedit =
         view(::PreeditTextView) {
@@ -56,7 +54,6 @@ open class PreeditUi(
         if (!preedit.isNullOrEmpty()) {
             append(preedit)
             setSpan(ForegroundColorSpan(highlightTextColor), selStart, selEnd, Spanned.SPAN_INCLUSIVE_EXCLUSIVE)
-            setSpan(BackgroundColorSpan(highlightBackColor), selStart, selEnd, Spanned.SPAN_INCLUSIVE_EXCLUSIVE)
         }
     }
 
@@ -71,10 +68,10 @@ open class PreeditUi(
         visibility = if (visible) View.VISIBLE else View.GONE
     }
 
-    fun update(inputComposition: CompositionProto) {
-        val string = inputComposition.toSpannedString()
-        val cursorPos = inputComposition.cursorPos
-        val hasPreedit = inputComposition.length > 0
+    fun update(composition: CompositionProto) {
+        val string = composition.toSpannedString()
+        val cursorPos = composition.cursorPos
+        val hasPreedit = composition.length > 0
         visible = hasPreedit
         if (!visible) {
             updateTextView("", false)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes # N/A

#### Feature
Describe features of this pull request

The background usually just wrap the text and distinguish it with the whole preedit area and make it look gross, so just remove it. 

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

