### PR TITLE
fix: remove duplicate padding for candidate items in unrolled candidates

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/candidates/unrolled/window/FlexboxUnrolledCandidateWindow.kt
+++ b/app/src/main/java/com/osfans/trime/ime/candidates/unrolled/window/FlexboxUnrolledCandidateWindow.kt
@@ -1,6 +1,7 @@
-// SPDX-FileCopyrightText: 2015 - 2024 Rime community
-//
-// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * SPDX-FileCopyrightText: 2015 - 2026 Rime community
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 package com.osfans.trime.ime.candidates.unrolled.window
 
@@ -18,7 +19,6 @@ import com.osfans.trime.ime.candidates.unrolled.decoration.FlexboxHorizontalDeco
 import com.osfans.trime.ime.window.BoardWindow
 import splitties.dimensions.dp
 import splitties.views.dsl.core.wrapContent
-import splitties.views.setPaddingDp
 
 class FlexboxUnrolledCandidateWindow : BaseUnrolledCandidateWindow() {
     override fun exitAnimation(nextWindow: BoardWindow): Transition = Slide().apply {
@@ -33,11 +33,10 @@ class FlexboxUnrolledCandidateWindow : BaseUnrolledCandidateWindow() {
             ): CandidateViewHolder = super.onCreateViewHolder(parent, viewType).apply {
                 itemView.apply {
                     minimumWidth = dp(40)
-                    val size = theme.generalStyle.candidatePadding
-                    setPaddingDp(size, 0, size, 0)
+                    val itemHeight = dp(theme.generalStyle.run { candidateViewHeight + commentHeight })
                     layoutParams =
                         FlexboxLayoutManager
-                            .LayoutParams(wrapContent, dp(theme.generalStyle.run { candidateViewHeight + commentHeight }))
+                            .LayoutParams(wrapContent, itemHeight)
                             .apply { flexGrow = 1f }
                 }
             }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes # N/A

#### Feature
Describe features of this pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

