### PR TITLE
feat: support word segmenting for clipboard and collection entries

### DIFF
--- a/app/src/main/java/com/osfans/trime/TrimeApplication.kt
+++ b/app/src/main/java/com/osfans/trime/TrimeApplication.kt
@@ -17,7 +17,6 @@ import androidx.preference.PreferenceManager
 import com.osfans.trime.data.db.ClipboardHelper
 import com.osfans.trime.data.db.CollectionHelper
 import com.osfans.trime.data.prefs.AppPrefs
-import com.osfans.trime.data.soundeffect.SoundEffectManager
 import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.receiver.RimeIntentReceiver
 import com.osfans.trime.ui.main.LogActivity

--- a/app/src/main/java/com/osfans/trime/ime/bar/InputBarDelegate.kt
+++ b/app/src/main/java/com/osfans/trime/ime/bar/InputBarDelegate.kt
@@ -236,6 +236,7 @@ class InputBarDelegate : InputBroadcastReceiver {
         val new = view.getChildAt(index)
         if (new != tabUi.root) {
             tabUi.setBackButtonOnClickListener { }
+            tabUi.setTitle("")
             tabUi.removeExternal()
         }
         view.displayedChild = index
@@ -271,6 +272,7 @@ class InputBarDelegate : InputBroadcastReceiver {
 
     override fun onWindowAttached(window: BoardWindow) {
         if (window is BoardWindow.BarBoardWindow) {
+            tabUi.setTitle(window.title)
             window.onCreateBarView()?.let { tabUi.addExternal(it, window.showTitle) }
             tabUi.setBackButtonOnClickListener {
                 windowManager.attachWindow(KeyboardWindow)

--- a/app/src/main/java/com/osfans/trime/ime/bar/ui/TabUi.kt
+++ b/app/src/main/java/com/osfans/trime/ime/bar/ui/TabUi.kt
@@ -6,9 +6,11 @@
 package com.osfans.trime.ime.bar.ui
 
 import android.content.Context
+import android.graphics.Typeface
 import android.view.View
 import androidx.core.view.isVisible
 import com.osfans.trime.R
+import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.Theme
 import splitties.dimensions.dp
 import splitties.views.dsl.constraintlayout.after
@@ -21,6 +23,9 @@ import splitties.views.dsl.constraintlayout.matchConstraints
 import splitties.views.dsl.constraintlayout.startOfParent
 import splitties.views.dsl.core.Ui
 import splitties.views.dsl.core.add
+import splitties.views.dsl.core.textView
+import splitties.views.dsl.core.wrapContent
+import splitties.views.gravityVerticalCenter
 
 class TabUi(
     override val ctx: Context,
@@ -42,6 +47,13 @@ class TabUi(
         }
     }
 
+    private val titleText = textView {
+        typeface = Typeface.defaultFromStyle(Typeface.BOLD)
+        gravity = gravityVerticalCenter
+        textSize = theme.generalStyle.candidateTextSize
+        setTextColor(ColorManager.getColor("key_text_color"))
+    }
+
     private var external: View? = null
 
     private val size = ctx.dp(theme.generalStyle.run { candidateViewHeight + commentHeight })
@@ -55,12 +67,23 @@ class TabUi(
                     centerVertically()
                 },
             )
+            add(
+                titleText,
+                lParams(wrapContent, size) {
+                    after(backButton, dp(8))
+                    centerVertically()
+                },
+            )
         }
 
     fun setBackButtonOnClickListener(block: () -> Unit) {
         backButton.setOnClickListener {
             block()
         }
+    }
+
+    fun setTitle(title: String) {
+        titleText.text = title
     }
 
     fun addExternal(
@@ -71,6 +94,7 @@ class TabUi(
             throw IllegalStateException("TabBar external view is already present")
         }
         backButton.isVisible = showTitle
+        titleText.isVisible = showTitle
         external = view
         root.run {
             add(
@@ -78,7 +102,7 @@ class TabUi(
                 lParams(matchConstraints, size) {
                     centerVertically()
                     if (showTitle) {
-                        after(backButton, dp(8))
+                        after(titleText, dp(8))
                         endOfParent()
                     } else {
                         centerHorizontally()

--- a/app/src/main/java/com/osfans/trime/ime/clipboard/ClipboardAdapter.kt
+++ b/app/src/main/java/com/osfans/trime/ime/clipboard/ClipboardAdapter.kt
@@ -90,6 +90,9 @@ abstract class ClipboardAdapter(
                 menu.item(R.string.share, R.drawable.ic_baseline_share_24, iconTint) {
                     onShare(bean)
                 }
+                menu.item(R.string.word_segment, R.drawable.ic_baseline_view_comfy_24, iconTint) {
+                    onSegment(bean)
+                }
 
                 if (enableCollection) {
                     menu.item(R.string.collect, R.drawable.ic_baseline_star_24, iconTint) {
@@ -131,6 +134,8 @@ abstract class ClipboardAdapter(
     abstract fun onEdit(id: Int)
 
     abstract fun onShare(bean: DatabaseBean)
+
+    abstract fun onSegment(bean: DatabaseBean)
 
     open fun onCollect(bean: DatabaseBean) {}
 

--- a/app/src/main/java/com/osfans/trime/ime/clipboard/ClipboardWindow.kt
+++ b/app/src/main/java/com/osfans/trime/ime/clipboard/ClipboardWindow.kt
@@ -22,6 +22,7 @@ import com.osfans.trime.data.theme.FontManager
 import com.osfans.trime.data.theme.Theme
 import com.osfans.trime.ime.core.TrimeInputMethodService
 import com.osfans.trime.ime.keyboard.KeyboardWindow
+import com.osfans.trime.ime.segments.SegmentsWindow
 import com.osfans.trime.ime.window.BoardWindow
 import com.osfans.trime.ime.window.BoardWindowManager
 import com.osfans.trime.ui.main.ClipEditActivity
@@ -79,6 +80,11 @@ class ClipboardWindow(private val initialTab: Int = 0) : BoardWindow.BarBoardWin
                 launchTextSharing(text)
             }
 
+            override fun onSegment(bean: DatabaseBean) {
+                val text = bean.text ?: return
+                windowManager.attachWindow(SegmentsWindow(text))
+            }
+
             override fun onCollect(bean: DatabaseBean) {
                 service.lifecycleScope.launch {
                     CollectionHelper.addNewBean(bean.text ?: "")
@@ -110,6 +116,11 @@ class ClipboardWindow(private val initialTab: Int = 0) : BoardWindow.BarBoardWin
             override fun onShare(bean: DatabaseBean) {
                 val text = bean.text ?: return
                 launchTextSharing(text)
+            }
+
+            override fun onSegment(bean: DatabaseBean) {
+                val text = bean.text ?: return
+                windowManager.attachWindow(SegmentsWindow(text))
             }
 
             override fun onDelete(id: Int) {

--- a/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
@@ -911,7 +911,7 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
         }
     }
 
-    private fun updateComposingText(text: String) {
+    internal fun updateComposingText(text: String) {
         val ic = currentInputConnection ?: return
         ic.beginBatchEdit()
         if (composingText.isNotEmpty() || text.isNotEmpty()) {

--- a/app/src/main/java/com/osfans/trime/ime/segments/DragSelectTouchListener.kt
+++ b/app/src/main/java/com/osfans/trime/ime/segments/DragSelectTouchListener.kt
@@ -5,23 +5,30 @@
 
 package com.osfans.trime.ime.segments
 
+import android.content.Context
 import android.view.MotionEvent
+import android.view.ViewConfiguration
 import androidx.recyclerview.widget.RecyclerView
+import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
 
 class DragSelectTouchListener(
+    context: Context,
     private val adapter: SegmentsAdapter,
     private val onSelectionChanged: () -> Unit,
 ) : RecyclerView.OnItemTouchListener {
 
     private var isDragSelecting = false
     private var startPosition = -1
-    private var endPosition = -1
     private var lastEndPosition = -1
     private var targetState = false
 
     private var selectionSnapshot: Set<Int> = emptySet()
+
+    private var initialX = 0f
+    private var initialY = 0f
+    private val touchSlop = ViewConfiguration.get(context).scaledTouchSlop
 
     override fun onInterceptTouchEvent(rv: RecyclerView, e: MotionEvent): Boolean {
         val child = rv.findChildViewUnder(e.x, e.y)
@@ -30,21 +37,48 @@ class DragSelectTouchListener(
         when (e.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
                 if (position != -1) {
-                    isDragSelecting = true
+                    initialX = e.x
+                    initialY = e.y
                     startPosition = position
-                    endPosition = position
-
-                    val snapshot = adapter.selectionSnapshot
-                    val state = !snapshot.contains(position)
-                    selectionSnapshot = snapshot
-                    targetState = state
-                    updateRange(rv, startPosition, startPosition)
-                    rv.parent?.requestDisallowInterceptTouchEvent(true)
-                    return true
+                    return false
                 }
             }
+            MotionEvent.ACTION_MOVE -> {
+                if (startPosition == -1) return false
+
+                if (!isDragSelecting) {
+                    val dx = abs(e.x - initialX)
+                    val dy = abs(e.y - initialY)
+
+                    if (dx > touchSlop || dy > touchSlop) {
+                        if (dx > dy) { // core condition: x offset larger than y offset
+                            isDragSelecting = true
+
+                            // disable scrolling
+                            rv.parent?.requestDisallowInterceptTouchEvent(true)
+
+                            // get the snapshot and judge the target state
+                            selectionSnapshot = adapter.selectionSnapshot
+                            targetState = !selectionSnapshot.contains(startPosition)
+
+                            // update state at start position immediately
+                            updateRange(rv, startPosition, startPosition)
+
+                            return true
+                        } else {
+                            // make scrolling still work
+                            startPosition = -1
+                            return false
+                        }
+                    }
+                }
+            }
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                startPosition = -1
+                isDragSelecting = false
+            }
         }
-        return false
+        return isDragSelecting
     }
 
     override fun onTouchEvent(rv: RecyclerView, e: MotionEvent) {
@@ -63,7 +97,6 @@ class DragSelectTouchListener(
             MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
                 isDragSelecting = false
                 startPosition = -1
-                endPosition = -1
                 lastEndPosition = -1
                 rv.parent?.requestDisallowInterceptTouchEvent(false)
                 onSelectionChanged.invoke()

--- a/app/src/main/java/com/osfans/trime/ime/segments/DragSelectTouchListener.kt
+++ b/app/src/main/java/com/osfans/trime/ime/segments/DragSelectTouchListener.kt
@@ -1,0 +1,99 @@
+/*
+ * SPDX-FileCopyrightText: 2015 - 2026 Rime community
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.osfans.trime.ime.segments
+
+import android.view.MotionEvent
+import androidx.recyclerview.widget.RecyclerView
+import kotlin.math.max
+import kotlin.math.min
+
+class DragSelectTouchListener(
+    private val adapter: SegmentsAdapter,
+    private val onSelectionChanged: () -> Unit,
+) : RecyclerView.OnItemTouchListener {
+
+    private var isDragSelecting = false
+    private var startPosition = -1
+    private var endPosition = -1
+    private var lastEndPosition = -1
+    private var targetState = false
+
+    private var selectionSnapshot: Set<Int> = emptySet()
+
+    override fun onInterceptTouchEvent(rv: RecyclerView, e: MotionEvent): Boolean {
+        val child = rv.findChildViewUnder(e.x, e.y)
+        val position = child?.let { rv.getChildAdapterPosition(it) } ?: -1
+
+        when (e.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                if (position != -1) {
+                    isDragSelecting = true
+                    startPosition = position
+                    endPosition = position
+
+                    val snapshot = adapter.selectionSnapshot
+                    val state = !snapshot.contains(position)
+                    selectionSnapshot = snapshot
+                    targetState = state
+                    updateRange(rv, startPosition, startPosition)
+                    rv.parent?.requestDisallowInterceptTouchEvent(true)
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    override fun onTouchEvent(rv: RecyclerView, e: MotionEvent) {
+        if (!isDragSelecting) return
+
+        val child = rv.findChildViewUnder(e.x, e.y)
+        val position = child?.let { rv.getChildAdapterPosition(it) } ?: -1
+
+        when (e.actionMasked) {
+            MotionEvent.ACTION_MOVE -> {
+                if (position != -1 && position != lastEndPosition) {
+                    updateRange(rv, startPosition, position)
+                    lastEndPosition = position
+                }
+            }
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                isDragSelecting = false
+                startPosition = -1
+                endPosition = -1
+                lastEndPosition = -1
+                rv.parent?.requestDisallowInterceptTouchEvent(false)
+                onSelectionChanged.invoke()
+            }
+        }
+    }
+
+    private fun updateRange(rv: RecyclerView, start: Int, end: Int) {
+        val minNew = min(start, end)
+        val maxNew = max(start, end)
+        val minOld = min(start, lastEndPosition)
+        val maxOld = max(start, lastEndPosition)
+
+        val minEval = min(minNew, minOld)
+        val maxEval = max(maxNew, maxOld)
+
+        for (i in minEval..maxEval) {
+            val isInsideNewRange = i in minNew..maxNew
+
+            val expectedState = if (isInsideNewRange) {
+                targetState
+            } else {
+                selectionSnapshot.contains(i)
+            }
+
+            if (adapter.isSegmentSelected(i) != expectedState) {
+                adapter.setSegmentSelected(i, expectedState)
+            }
+        }
+    }
+
+    override fun onRequestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {}
+}

--- a/app/src/main/java/com/osfans/trime/ime/segments/SegmentUi.kt
+++ b/app/src/main/java/com/osfans/trime/ime/segments/SegmentUi.kt
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: 2015 - 2026 Rime community
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.osfans.trime.ime.segments
+
+import android.content.Context
+import android.content.res.ColorStateList
+import android.graphics.drawable.StateListDrawable
+import android.view.ViewOutlineProvider
+import com.osfans.trime.data.theme.ColorManager
+import com.osfans.trime.data.theme.FontManager
+import com.osfans.trime.data.theme.Theme
+import com.osfans.trime.ime.keyboard.GestureFrame
+import splitties.dimensions.dp
+import splitties.views.dsl.core.Ui
+import splitties.views.dsl.core.add
+import splitties.views.dsl.core.lParams
+import splitties.views.dsl.core.matchParent
+import splitties.views.dsl.core.textView
+import splitties.views.dsl.core.wrapContent
+import splitties.views.gravityCenter
+import splitties.views.setPaddingDp
+
+class SegmentUi(override val ctx: Context, theme: Theme) : Ui {
+    val textView =
+        textView {
+            textSize = 16f
+            isSingleLine = true
+            typeface = FontManager.getTypeface("key_font")
+            setPaddingDp(8, 4, 8, 4)
+            setTextColor(
+                ColorStateList(
+                    arrayOf(
+                        intArrayOf(-android.R.attr.state_selected),
+                        intArrayOf(android.R.attr.state_selected),
+                    ),
+                    intArrayOf(
+                        ColorManager.getColor("key_text_color"),
+                        ColorManager.getColor("hilited_key_text_color"),
+                    ),
+                ),
+            )
+        }
+
+    override val root = GestureFrame(ctx).apply {
+        isClickable = true
+        background = StateListDrawable().apply {
+            addState(
+                intArrayOf(-android.R.attr.state_selected),
+                ColorManager.getDecorDrawable(
+                    "key_back_color",
+                    cornerRadius = ctx.dp(theme.generalStyle.roundCorner),
+                ),
+            )
+            addState(
+                intArrayOf(android.R.attr.state_selected),
+                ColorManager.getDecorDrawable(
+                    "hilited_key_back_color",
+                    cornerRadius = dp(theme.generalStyle.roundCorner),
+                ),
+            )
+        }
+        clipToOutline = true
+        outlineProvider = ViewOutlineProvider.BACKGROUND
+        add(
+            textView,
+            lParams(wrapContent, wrapContent) {
+                gravity = gravityCenter
+            },
+        )
+    }
+
+    fun update(isSelected: Boolean) {
+        root.isSelected = isSelected
+        textView.isSelected = isSelected
+    }
+}

--- a/app/src/main/java/com/osfans/trime/ime/segments/SegmentUi.kt
+++ b/app/src/main/java/com/osfans/trime/ime/segments/SegmentUi.kt
@@ -8,12 +8,14 @@ package com.osfans.trime.ime.segments
 import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.drawable.StateListDrawable
+import android.os.Build
 import android.view.ViewOutlineProvider
 import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.FontManager
 import com.osfans.trime.data.theme.Theme
 import com.osfans.trime.ime.keyboard.GestureFrame
 import splitties.dimensions.dp
+import splitties.resources.styledDrawable
 import splitties.views.dsl.core.Ui
 import splitties.views.dsl.core.add
 import splitties.views.dsl.core.lParams

--- a/app/src/main/java/com/osfans/trime/ime/segments/SegmentsAdapter.kt
+++ b/app/src/main/java/com/osfans/trime/ime/segments/SegmentsAdapter.kt
@@ -8,14 +8,14 @@ package com.osfans.trime.ime.segments
 import android.annotation.SuppressLint
 import android.content.Context
 import android.view.ViewGroup
-import androidx.core.view.updateLayoutParams
 import androidx.recyclerview.widget.RecyclerView
 import com.chad.library.adapter4.BaseQuickAdapter
-import com.google.android.flexbox.FlexboxLayoutManager
 import com.osfans.trime.data.theme.Theme
-import splitties.dimensions.dp
 
-class SegmentsAdapter(private val theme: Theme) : BaseQuickAdapter<String, SegmentsAdapter.ViewHolder>() {
+class SegmentsAdapter(
+    private val theme: Theme,
+    private val onItemClick: () -> Unit,
+) : BaseQuickAdapter<String, SegmentsAdapter.ViewHolder>() {
 
     class ViewHolder(val ui: SegmentUi) : RecyclerView.ViewHolder(ui.root)
 
@@ -36,6 +36,14 @@ class SegmentsAdapter(private val theme: Theme) : BaseQuickAdapter<String, Segme
         holder.ui.textView.text = text
         val isSelected = selection.contains(position)
         holder.ui.update(isSelected)
+        holder.itemView.setOnClickListener {
+            val currentPos = holder.bindingAdapterPosition
+            if (currentPos != RecyclerView.NO_POSITION) {
+                val newState = !isSegmentSelected(currentPos)
+                setSegmentSelected(currentPos, newState)
+                onItemClick.invoke()
+            }
+        }
     }
 
     val selectionSnapshot: Set<Int>

--- a/app/src/main/java/com/osfans/trime/ime/segments/SegmentsAdapter.kt
+++ b/app/src/main/java/com/osfans/trime/ime/segments/SegmentsAdapter.kt
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: 2015 - 2026 Rime community
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.osfans.trime.ime.segments
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.view.ViewGroup
+import androidx.core.view.updateLayoutParams
+import androidx.recyclerview.widget.RecyclerView
+import com.chad.library.adapter4.BaseQuickAdapter
+import com.google.android.flexbox.FlexboxLayoutManager
+import com.osfans.trime.data.theme.Theme
+import splitties.dimensions.dp
+
+class SegmentsAdapter(private val theme: Theme) : BaseQuickAdapter<String, SegmentsAdapter.ViewHolder>() {
+
+    class ViewHolder(val ui: SegmentUi) : RecyclerView.ViewHolder(ui.root)
+
+    private val selection = mutableSetOf<Int>()
+
+    override fun onCreateViewHolder(
+        context: Context,
+        parent: ViewGroup,
+        viewType: Int,
+    ): ViewHolder = ViewHolder(SegmentUi(context, theme))
+
+    override fun onBindViewHolder(
+        holder: ViewHolder,
+        position: Int,
+        item: String?,
+    ) {
+        val text = item ?: return
+        holder.ui.textView.text = text
+        val isSelected = selection.contains(position)
+        holder.ui.update(isSelected)
+    }
+
+    val selectionSnapshot: Set<Int>
+        get() = selection.toSet()
+
+    fun isSegmentSelected(position: Int): Boolean = selection.contains(position)
+
+    fun setSegmentSelected(position: Int, isSelected: Boolean) {
+        if (isSelected) {
+            selection.add(position)
+        } else {
+            selection.remove(position)
+        }
+        notifyItemChanged(position)
+    }
+
+    @SuppressLint("NotifyDataSetChanged")
+    fun selectAll() {
+        if (isAllSelected) return
+        selection.clear()
+        selection.addAll(items.indices)
+        notifyDataSetChanged()
+    }
+
+    @SuppressLint("NotifyDataSetChanged")
+    fun deselect() {
+        if (selection.isEmpty()) return
+        selection.clear()
+        notifyDataSetChanged()
+    }
+
+    val isAllSelected: Boolean
+        get() = selection.size == items.size
+
+    val joinedSegments: String
+        get() = items.asSequence()
+            .filterIndexed { i, _ -> isSegmentSelected(i) }
+            .joinToString("")
+}

--- a/app/src/main/java/com/osfans/trime/ime/segments/SegmentsUi.kt
+++ b/app/src/main/java/com/osfans/trime/ime/segments/SegmentsUi.kt
@@ -1,0 +1,88 @@
+/*
+ * SPDX-FileCopyrightText: 2015 - 2026 Rime community
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.osfans.trime.ime.segments
+
+import android.content.Context
+import com.google.android.flexbox.AlignItems
+import com.google.android.flexbox.FlexDirection
+import com.google.android.flexbox.FlexboxLayout
+import com.google.android.flexbox.JustifyContent
+import com.osfans.trime.R
+import com.osfans.trime.ime.bar.ui.ToolButton
+import com.osfans.trime.ime.symbol.SpacesItemDecoration
+import splitties.dimensions.dp
+import splitties.views.dsl.constraintlayout.bottomOfParent
+import splitties.views.dsl.constraintlayout.bottomToTopOf
+import splitties.views.dsl.constraintlayout.centerHorizontally
+import splitties.views.dsl.constraintlayout.constraintLayout
+import splitties.views.dsl.constraintlayout.lParams
+import splitties.views.dsl.constraintlayout.matchConstraints
+import splitties.views.dsl.constraintlayout.startOfParent
+import splitties.views.dsl.constraintlayout.topOfParent
+import splitties.views.dsl.constraintlayout.topToBottomOf
+import splitties.views.dsl.core.Ui
+import splitties.views.dsl.core.add
+import splitties.views.dsl.core.matchParent
+import splitties.views.dsl.core.view
+import splitties.views.dsl.core.wrapContent
+import splitties.views.dsl.recyclerview.recyclerView
+
+class SegmentsUi(override val ctx: Context) : Ui {
+    val recyclerView = recyclerView {
+        itemAnimator = null
+        addItemDecoration(SpacesItemDecoration(dp(4)))
+    }
+
+    val selectButton = ToolButton(ctx, R.drawable.ic_baseline_select_all_24)
+
+    val shareButton = ToolButton(ctx, R.drawable.ic_baseline_share_24)
+
+    val searchButton = ToolButton(ctx, R.drawable.ic_baseline_search_24)
+
+    val starButton = ToolButton(ctx, R.drawable.ic_baseline_star_24)
+
+    val copyButton = ToolButton(ctx, R.drawable.ic_baseline_content_copy_24)
+
+    private val buttons = view(::FlexboxLayout) {
+        flexDirection = FlexDirection.ROW
+        alignItems = AlignItems.CENTER
+        justifyContent = JustifyContent.SPACE_AROUND
+
+        val size = dp(48)
+        add(selectButton, FlexboxLayout.LayoutParams(size, size))
+        add(shareButton, FlexboxLayout.LayoutParams(size, size))
+        add(searchButton, FlexboxLayout.LayoutParams(size, size))
+        add(starButton, FlexboxLayout.LayoutParams(size, size))
+        add(copyButton, FlexboxLayout.LayoutParams(size, size))
+    }
+
+    override val root = constraintLayout {
+        add(
+            recyclerView,
+            lParams(matchParent, matchConstraints) {
+                topOfParent(dp(4))
+                centerHorizontally(dp(8))
+                bottomToTopOf(buttons)
+            },
+        )
+        add(
+            buttons,
+            lParams(matchParent, wrapContent) {
+                topToBottomOf(recyclerView)
+                startOfParent(dp(8))
+                bottomOfParent(dp(4))
+            },
+        )
+    }
+
+    fun setSelectButtonToSelectAll() {
+        selectButton.setIcon(R.drawable.ic_baseline_select_all_24)
+    }
+
+    fun setSelectButtonToDeselect() {
+        selectButton.setIcon(R.drawable.ic_baseline_deselect_24)
+    }
+}

--- a/app/src/main/java/com/osfans/trime/ime/segments/SegmentsWindow.kt
+++ b/app/src/main/java/com/osfans/trime/ime/segments/SegmentsWindow.kt
@@ -1,0 +1,143 @@
+/*
+ * SPDX-FileCopyrightText: 2015 - 2026 Rime community
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.osfans.trime.ime.segments
+
+import android.app.SearchManager
+import android.content.ClipData
+import android.content.Intent
+import androidx.lifecycle.lifecycleScope
+import com.google.android.flexbox.AlignItems
+import com.google.android.flexbox.FlexDirection
+import com.google.android.flexbox.FlexWrap
+import com.google.android.flexbox.FlexboxLayoutManager
+import com.osfans.trime.R
+import com.osfans.trime.data.db.CollectionHelper
+import com.osfans.trime.data.theme.Theme
+import com.osfans.trime.ime.core.TrimeInputMethodService
+import com.osfans.trime.ime.keyboard.KeyboardWindow
+import com.osfans.trime.ime.window.BoardWindow
+import com.osfans.trime.ime.window.BoardWindowManager
+import com.osfans.trime.util.NativeTokenizer
+import com.osfans.trime.util.toast
+import kotlinx.coroutines.launch
+import org.kodein.di.instance
+import splitties.systemservices.clipboardManager
+
+class SegmentsWindow(private val source: String) : BoardWindow.BarBoardWindow() {
+    private val service: TrimeInputMethodService by di.instance()
+    private val theme: Theme by di.instance()
+    private val windowManager: BoardWindowManager by di.instance()
+
+    override val title: String by lazy {
+        context.getString(R.string.word_segment)
+    }
+
+    private val adapter by lazy {
+        SegmentsAdapter(theme)
+    }
+
+    private val touchListener by lazy {
+        DragSelectTouchListener(adapter) {
+            onSelectionChanged()
+        }
+    }
+
+    private val ui by lazy {
+        SegmentsUi(context).apply {
+            recyclerView.apply {
+                layoutManager = FlexboxLayoutManager(context).apply {
+                    flexDirection = FlexDirection.ROW
+                    flexWrap = FlexWrap.WRAP
+                    alignItems = AlignItems.FLEX_START
+                }
+                adapter = this@SegmentsWindow.adapter
+            }
+            selectButton.setOnClickListener {
+                if (adapter.isAllSelected) {
+                    adapter.deselect()
+                } else {
+                    adapter.selectAll()
+                }
+                onSelectionChanged()
+            }
+            shareButton.apply {
+                isEnabled = false
+                setOnClickListener {
+                    val text = adapter.joinedSegments
+                    val target = Intent(Intent.ACTION_SEND).apply {
+                        type = "text/plain"
+                        putExtra(Intent.EXTRA_TEXT, text)
+                    }
+                    val chooser = Intent.createChooser(target, null).apply {
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                    service.startActivity(chooser)
+                }
+            }
+            searchButton.apply {
+                isEnabled = false
+                setOnClickListener {
+                    val text = adapter.joinedSegments
+                    val intent = Intent(Intent.ACTION_WEB_SEARCH).apply {
+                        putExtra(SearchManager.QUERY, text)
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                    service.startActivity(intent)
+                }
+            }
+            starButton.apply {
+                isEnabled = false
+                setOnClickListener {
+                    val text = adapter.joinedSegments
+                    service.lifecycleScope.launch {
+                        CollectionHelper.addNewBean(text)
+                    }
+                    ctx.toast(R.string.star_success)
+                }
+            }
+            copyButton.apply {
+                isEnabled = false
+                setOnClickListener {
+                    val text = adapter.joinedSegments
+                    clipboardManager.setPrimaryClip(ClipData.newPlainText("", text))
+                    windowManager.attachWindow(KeyboardWindow)
+                }
+            }
+        }
+    }
+
+    private fun onSelectionChanged() {
+        val joined = adapter.joinedSegments
+        service.updateComposingText(joined)
+
+        if (adapter.isAllSelected) {
+            ui.setSelectButtonToDeselect()
+        } else {
+            ui.setSelectButtonToSelectAll()
+        }
+
+        val hasSelection = adapter.selectionSnapshot.isNotEmpty()
+        ui.shareButton.isEnabled = hasSelection
+        ui.searchButton.isEnabled = hasSelection
+        ui.starButton.isEnabled = hasSelection
+        ui.copyButton.isEnabled = hasSelection
+    }
+
+    override fun onCreateView() = ui.root
+
+    override fun onAttached() {
+        val segments = NativeTokenizer.tokenize(source)
+        service.lifecycleScope.launch {
+            adapter.submitList(segments)
+        }
+        ui.recyclerView.addOnItemTouchListener(touchListener)
+    }
+
+    override fun onDetached() {
+        ui.recyclerView.removeOnItemTouchListener(touchListener)
+        service.currentInputConnection?.finishComposingText()
+    }
+}

--- a/app/src/main/java/com/osfans/trime/ime/segments/SegmentsWindow.kt
+++ b/app/src/main/java/com/osfans/trime/ime/segments/SegmentsWindow.kt
@@ -36,11 +36,11 @@ class SegmentsWindow(private val source: String) : BoardWindow.BarBoardWindow() 
     }
 
     private val adapter by lazy {
-        SegmentsAdapter(theme)
+        SegmentsAdapter(theme) { onSelectionChanged() }
     }
 
     private val touchListener by lazy {
-        DragSelectTouchListener(adapter) {
+        DragSelectTouchListener(context, adapter) {
             onSelectionChanged()
         }
     }

--- a/app/src/main/java/com/osfans/trime/ime/switches/SwitchOptionWindow.kt
+++ b/app/src/main/java/com/osfans/trime/ime/switches/SwitchOptionWindow.kt
@@ -28,7 +28,6 @@ import com.osfans.trime.util.AppUtils
 import kotlinx.coroutines.launch
 import org.kodein.di.instance
 import splitties.dimensions.dp
-import splitties.views.dsl.constraintlayout.centerVertically
 import splitties.views.dsl.constraintlayout.constraintLayout
 import splitties.views.dsl.constraintlayout.endOfParent
 import splitties.views.dsl.constraintlayout.lParams
@@ -195,7 +194,6 @@ class SwitchOptionWindow :
                 settingsButton,
                 lParams(size, size) {
                     endOfParent()
-                    centerVertically()
                 },
             )
         }

--- a/app/src/main/java/com/osfans/trime/ime/window/BoardWindow.kt
+++ b/app/src/main/java/com/osfans/trime/ime/window/BoardWindow.kt
@@ -52,6 +52,8 @@ sealed class BoardWindow {
     abstract class BarBoardWindow : BoardWindow() {
         open val showTitle: Boolean = true
 
+        open val title: String = ""
+
         open fun onCreateBarView(): View? = null
 
         override fun toString(): String = javaClass.name

--- a/app/src/main/java/com/osfans/trime/util/NativeTokenizer.kt
+++ b/app/src/main/java/com/osfans/trime/util/NativeTokenizer.kt
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: 2015 - 2026 Rime community
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.osfans.trime.util
+
+import android.os.Build
+
+object NativeTokenizer {
+    /**
+     * Utilize Android native ICU engine to tokenize text
+     * API 24+ uses android.icu.text, otherwise uses java.text
+     *
+     * @param text original text
+     * @param filterBlank filter the whitespace characters
+     */
+    fun tokenize(text: String, filterBlank: Boolean = true): List<String> {
+        if (text.isEmpty()) return emptyList()
+        val words = mutableListOf<String>()
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            val iterator = android.icu.text.BreakIterator.getWordInstance().apply { setText(text) }
+            var start = iterator.first()
+            var end = iterator.next()
+            while (end != android.icu.text.BreakIterator.DONE) {
+                val word = text.substring(start, end)
+                if (!filterBlank || word.isNotBlank()) words.add(word)
+                start = end
+                end = iterator.next()
+            }
+        } else {
+            val iterator = java.text.BreakIterator.getWordInstance().apply { setText(text) }
+            var start = iterator.first()
+            var end = iterator.next()
+            while (end != java.text.BreakIterator.DONE) {
+                val word = text.substring(start, end)
+                if (!filterBlank || word.isNotBlank()) words.add(word)
+                start = end
+                end = iterator.next()
+            }
+        }
+        return words
+    }
+}

--- a/app/src/main/res/drawable/ic_baseline_content_copy_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_content_copy_24.xml
@@ -1,0 +1,17 @@
+<!--
+  ~ SPDX-FileCopyrightText: 2015 - 2026 Rime community
+  ~ SPDX-License-Identifier: GPL-3.0-or-later
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#FFFFFF"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M16,1L4,1c-1.1,0 -2,0.9 -2,2v14h2L4,3h12L16,1zM19,5L8,5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h11c1.1,0 2,-0.9 2,-2L21,7c0,-1.1 -0.9,-2 -2,-2zM19,21L8,21L8,7h11v14z" />
+
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_deselect_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_deselect_24.xml
@@ -1,0 +1,16 @@
+<!--
+  ~ SPDX-FileCopyrightText: 2015 - 2026 Rime community
+  ~ SPDX-License-Identifier: GPL-3.0-or-later
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,13h2v-2H3V13zM7,21h2v-2H7V21zM13,3h-2v2h2V3zM19,3v2h2C21,3.9 20.1,3 19,3zM5,21v-2H3C3,20.1 3.9,21 5,21zM3,17h2v-2H3V17zM11,21h2v-2h-2V21zM19,13h2v-2h-2V13zM19,9h2V7h-2V9zM15,5h2V3h-2V5zM7.83,5L7,4.17V3h2v2H7.83zM19.83,17L19,16.17V15h2v2H19.83zM21.19,21.19L2.81,2.81L1.39,4.22L4.17,7H3v2h2V7.83l2,2V17h7.17l2,2H15v2h2v-1.17l2.78,2.78L21.19,21.19zM9,15v-3.17L12.17,15H9zM15,12.17V9h-3.17l-2,-2H17v7.17L15,12.17z" />
+
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_search_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_search_24.xml
@@ -1,0 +1,16 @@
+<!--
+  ~ SPDX-FileCopyrightText: 2015 - 2026 Rime community
+  ~ SPDX-License-Identifier: GPL-3.0-or-later
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z" />
+
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_select_all_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_select_all_24.xml
@@ -1,0 +1,16 @@
+<!--
+  ~ SPDX-FileCopyrightText: 2015 - 2026 Rime community
+  ~ SPDX-License-Identifier: GPL-3.0-or-later
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,5h2L5,3c-1.1,0 -2,0.9 -2,2zM3,13h2v-2L3,11v2zM7,21h2v-2L7,19v2zM3,9h2L5,7L3,7v2zM13,3h-2v2h2L13,3zM19,3v2h2c0,-1.1 -0.9,-2 -2,-2zM5,21v-2L3,19c0,1.1 0.9,2 2,2zM3,17h2v-2L3,15v2zM9,3L7,3v2h2L9,3zM11,21h2v-2h-2v2zM19,13h2v-2h-2v2zM19,21c1.1,0 2,-0.9 2,-2h-2v2zM19,9h2L21,7h-2v2zM19,17h2v-2h-2v2zM15,21h2v-2h-2v2zM15,5h2L17,3h-2v2zM7,17h10L17,7L7,7v10zM9,9h6v6L9,15L9,9z" />
+
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_view_comfy_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_view_comfy_24.xml
@@ -1,0 +1,16 @@
+<!--
+  ~ SPDX-FileCopyrightText: 2015 - 2026 Rime community
+  ~ SPDX-License-Identifier: GPL-3.0-or-later
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,9h4L7,5L3,5v4zM3,14h4v-4L3,10v4zM8,14h4v-4L8,10v4zM13,14h4v-4h-4v4zM8,9h4L12,5L8,5v4zM13,5v4h4L17,5h-4zM18,14h4v-4h-4v4zM3,19h4v-4L3,15v4zM8,19h4v-4L8,15v4zM13,19h4v-4h-4v4zM18,19h4v-4h-4v4zM18,5v4h4L22,5h-4z" />
+
+</vector>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -216,4 +216,6 @@
     <string name="inline_suggestions">显示内嵌自动填充建议</string>
     <string name="update_config">更新配置</string>
     <string name="share">分享</string>
+    <string name="word_segment">分词</string>
+    <string name="star_success">收藏成功</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -217,4 +217,6 @@
     <string name="inline_suggestions">顯示內嵌自動填充建議</string>
     <string name="update_config">更新配置</string>
     <string name="share">分享</string>
+    <string name="word_segment">分词</string>
+    <string name="star_success">收藏成功</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -217,4 +217,6 @@
     <string name="inline_suggestions">Show inline autofill suggestions</string>
     <string name="update_config">Update config</string>
     <string name="share">Share</string>
+    <string name="word_segment">Word segment</string>
+    <string name="star_success">Star success</string>
 </resources>


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes # N/A

#### Feature
Describe features of this pull request

- Introduce jieba-android dependency to support word segmenting
- Add title text to TabUi
- Add sharing support for clipboard and collection entries
- Fix that settings button in SwitchOptionWindow's header didn't place to end

**Note**: The apk size will increse about 2.2 MB (total ~11.1 MB), I think it's acceptable.

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

