### PR TITLE
fix(theme): fallback to available theme when selected is missing

### DIFF
--- a/app/src/main/java/com/osfans/trime/data/theme/ThemeManager.kt
+++ b/app/src/main/java/com/osfans/trime/data/theme/ThemeManager.kt
@@ -69,7 +69,13 @@ object ThemeManager {
         }
         return try {
             val node = Yaml.parseToYamlNode(file.readText())
-            Theme.decode(node.mapping!!)
+            val mapping = node.mapping
+            if (mapping == null) {
+                Timber.w("Failed to load theme '$id': YAML root is not a mapping")
+                null
+            } else {
+                Theme.decode(mapping)
+            }
         } catch (e: Exception) {
             Timber.w(e, "Failed to load theme '$id'")
             null

--- a/app/src/main/java/com/osfans/trime/data/theme/ThemeManager.kt
+++ b/app/src/main/java/com/osfans/trime/data/theme/ThemeManager.kt
@@ -92,16 +92,12 @@ object ThemeManager {
             }
         }
 
-        getAllThemes()
-            .asSequence()
-            .map { it.configId }
-            .distinct()
-            .forEach { fallbackId ->
-                loadThemeByIdOrNull(fallbackId)?.let {
-                    Timber.w("Theme '$id' is unavailable, fallback to available theme '$fallbackId'")
-                    return ResolvedTheme(fallbackId, it)
-                }
+        for (fallbackId in getAllThemes().map { it.configId }.distinct()) {
+            loadThemeByIdOrNull(fallbackId)?.let {
+                Timber.w("Theme '$id' is unavailable, fallback to available theme '$fallbackId'")
+                return ResolvedTheme(fallbackId, it)
             }
+        }
 
         error("No valid theme available")
     }

--- a/app/src/main/java/com/osfans/trime/data/theme/ThemeManager.kt
+++ b/app/src/main/java/com/osfans/trime/data/theme/ThemeManager.kt
@@ -53,17 +53,60 @@ object ThemeManager {
 
     val prefs = AppPrefs.defaultInstance().registerProvider(::ThemePrefs)
 
-    private fun getThemeById(id: String): Theme {
+    private data class ResolvedTheme(
+        val configId: String,
+        val theme: Theme,
+    )
+
+    private fun loadThemeByIdOrNull(id: String): Theme? {
         if (!Rime.deployRimeConfigFile(id, "config_version")) {
             Timber.w("Failed to deploy theme config file '$id.yaml'")
         }
         val file = File(DataManager.resolveDeployedResourcePath(id))
-        val node = Yaml.parseToYamlNode(file.readText())
-        return Theme.decode(node.mapping!!)
+        if (!file.exists()) {
+            Timber.w("Theme file not found for '$id'")
+            return null
+        }
+        return try {
+            val node = Yaml.parseToYamlNode(file.readText())
+            Theme.decode(node.mapping!!)
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to load theme '$id'")
+            null
+        }
+    }
+
+    private fun getThemeById(id: String): ResolvedTheme {
+        loadThemeByIdOrNull(id)?.let { return ResolvedTheme(id, it) }
+
+        if (id != "trime") {
+            loadThemeByIdOrNull("trime")?.let {
+                Timber.w("Theme '$id' is unavailable, fallback to default theme 'trime'")
+                return ResolvedTheme("trime", it)
+            }
+        }
+
+        getAllThemes()
+            .asSequence()
+            .map { it.configId }
+            .distinct()
+            .forEach { fallbackId ->
+                loadThemeByIdOrNull(fallbackId)?.let {
+                    Timber.w("Theme '$id' is unavailable, fallback to available theme '$fallbackId'")
+                    return ResolvedTheme(fallbackId, it)
+                }
+            }
+
+        error("No valid theme available")
     }
 
     private fun evaluateActiveTheme(): Theme {
-        val newTheme = getThemeById(prefs.selectedTheme.getValue())
+        val selectedThemeId = prefs.selectedTheme.getValue()
+        val resolvedTheme = getThemeById(selectedThemeId)
+        val newTheme = resolvedTheme.theme
+        if (resolvedTheme.configId != selectedThemeId) {
+            prefs.selectedTheme.setValue(resolvedTheme.configId)
+        }
         KeyActionManager.resetCache()
         FontManager.resetCache(newTheme)
         ColorManager.switchTheme(newTheme)
@@ -77,12 +120,13 @@ object ThemeManager {
     }
 
     fun selectTheme(configId: String) {
-        val theme = getThemeById(configId)
+        val resolvedTheme = getThemeById(configId)
+        val theme = resolvedTheme.theme
         KeyActionManager.resetCache()
         FontManager.resetCache(theme)
         ColorManager.switchTheme(theme)
         LiquidData.init(theme)
         activeTheme = theme
-        prefs.selectedTheme.setValue(configId)
+        prefs.selectedTheme.setValue(resolvedTheme.configId)
     }
 }


### PR DESCRIPTION
Load themes defensively and provide fallbacks when the selected theme is unavailable. Use a safe loader that returns null for missing files or parse
errors and logs warnings. If the requested theme cannot be loaded, try the
default 'trime' theme, then any other deployed theme as a fallback. Persist
the resolved config id to prefs.selectedTheme to avoid repeated fallbacks and
ensure caches and managers remain in sync. This prevents crashes on invalid or
missing theme files.

<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Show

before:

https://github.com/user-attachments/assets/b20ee232-fcad-4abc-8b22-4644911ddc02

after:

https://github.com/user-attachments/assets/4e97a069-8d02-47d0-931c-0331accd4e40


#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

