### PR TITLE
feat(ime): hardware-keyboard / toolbar-only layout support

### DIFF
--- a/app/src/main/java/com/osfans/trime/data/prefs/AppPrefs.kt
+++ b/app/src/main/java/com/osfans/trime/data/prefs/AppPrefs.kt
@@ -10,10 +10,12 @@ import android.content.SharedPreferences
 import androidx.annotation.Keep
 import com.osfans.trime.R
 import com.osfans.trime.data.base.DataManager
+import com.osfans.trime.ime.bar.ToolbarPosition
 import com.osfans.trime.ime.candidates.compact.CompactCandidateMode
 import com.osfans.trime.ime.candidates.popup.PopupCandidatesLayout
 import com.osfans.trime.ime.candidates.popup.PopupCandidatesMode
 import com.osfans.trime.ime.composition.PopupPosition
+import com.osfans.trime.ime.core.HideVirtualKeyboardMode
 import com.osfans.trime.ime.core.InlinePreeditMode
 import com.osfans.trime.util.InputMethodUtils
 import com.osfans.trime.util.appContext
@@ -124,6 +126,8 @@ class AppPrefs(
 
             const val USE_SOFT_CURSOR = "use_soft_cursor"
             const val HIDE_INPUT_BAR = "hide_input_bar"
+            const val TOOLBAR_POSITION = "toolbar_position"
+            const val HIDE_VIRTUAL_KEYBOARD = "hide_virtual_keyboard"
 
             const val SOUND_ON_KEYPRESS = "sound_on_keypress"
             const val KEY_SOUND_VOLUME = "sound_volume"
@@ -179,6 +183,11 @@ class AppPrefs(
         val useSoftCursor = switch(R.string.use_soft_cursor, USE_SOFT_CURSOR, true)
 
         val hideInputBar = switch(R.string.hide_input_bar, HIDE_INPUT_BAR, false)
+
+        val toolbarPosition = enum(R.string.toolbar_position, TOOLBAR_POSITION, ToolbarPosition.TOP)
+
+        val hideVirtualKeyboard =
+            enum(R.string.hide_virtual_keyboard, HIDE_VIRTUAL_KEYBOARD, HideVirtualKeyboardMode.NEVER)
 
         val soundOnKeyPress = switch(R.string.sound_on_keypress, SOUND_ON_KEYPRESS, false)
         val soundVolume = int(

--- a/app/src/main/java/com/osfans/trime/ime/bar/ToolbarPosition.kt
+++ b/app/src/main/java/com/osfans/trime/ime/bar/ToolbarPosition.kt
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: 2015 - 2026 Rime community
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.osfans.trime.ime.bar
+
+import com.osfans.trime.R
+import com.osfans.trime.data.prefs.PreferenceDelegateEnum
+
+enum class ToolbarPosition(
+    override val stringRes: Int,
+) : PreferenceDelegateEnum {
+    TOP(R.string.toolbar_position_top),
+    BOTTOM(R.string.toolbar_position_bottom),
+}

--- a/app/src/main/java/com/osfans/trime/ime/core/HideVirtualKeyboardMode.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/HideVirtualKeyboardMode.kt
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: 2015 - 2026 Rime community
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.osfans.trime.ime.core
+
+import com.osfans.trime.R
+import com.osfans.trime.data.prefs.PreferenceDelegateEnum
+
+enum class HideVirtualKeyboardMode(
+    override val stringRes: Int,
+) : PreferenceDelegateEnum {
+    NEVER(R.string.hide_virtual_keyboard_never),
+    AUTO(R.string.hide_virtual_keyboard_auto),
+    ALWAYS(R.string.hide_virtual_keyboard_always),
+}

--- a/app/src/main/java/com/osfans/trime/ime/core/InputDeviceManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/InputDeviceManager.kt
@@ -5,6 +5,7 @@
 
 package com.osfans.trime.ime.core
 
+import android.content.res.Configuration
 import android.text.InputType
 import android.view.KeyEvent
 import android.view.MotionEvent
@@ -22,13 +23,39 @@ class InputDeviceManager(
     private var candidatesView: CandidatesView? = null
 
     private val candidatesViewMode by AppPrefs.defaultInstance().candidates.mode
+    private val hideVirtualKeyboardMode by AppPrefs.defaultInstance().keyboard.hideVirtualKeyboard
 
     private val alwaysShowCandidatesView: Boolean
         get() = candidatesViewMode == PopupCandidatesMode.ALWAYS_SHOW
 
+    private fun hasHardwareKeyboard(): Boolean {
+        val cfg = inputView?.resources?.configuration ?: return false
+        return cfg.keyboard != Configuration.KEYBOARD_NOKEYS &&
+            cfg.hardKeyboardHidden != Configuration.HARDKEYBOARDHIDDEN_YES
+    }
+
+    private fun shouldHideKeyboardArea(): Boolean =
+        when (hideVirtualKeyboardMode) {
+            HideVirtualKeyboardMode.NEVER -> false
+            HideVirtualKeyboardMode.ALWAYS -> true
+            HideVirtualKeyboardMode.AUTO -> hasHardwareKeyboard()
+        }
+
     private fun setupInputViewCallback(isVirtual: Boolean) {
-        inputView?.handleMessages = isVirtual
-        inputView?.visibility = if (isVirtual) View.VISIBLE else View.GONE
+        val v = inputView ?: return
+        v.handleMessages = isVirtual
+        val hideKeyboardArea = shouldHideKeyboardArea()
+        if (isVirtual) {
+            v.visibility = View.VISIBLE
+            v.setKeyboardAreaVisible(!hideKeyboardArea)
+        } else if (hideKeyboardArea) {
+            // Toolbar-only mode: keep InputView attached so the toolbar (and clipboard/inline
+            // suggestions) stay visible, but hide the virtual keyboard area.
+            v.visibility = View.VISIBLE
+            v.setKeyboardAreaVisible(false)
+        } else {
+            v.visibility = View.GONE
+        }
     }
 
     private fun setupCandidatesViewCallback(isVirtual: Boolean) {

--- a/app/src/main/java/com/osfans/trime/ime/core/InputDeviceManager.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/InputDeviceManager.kt
@@ -34,12 +34,11 @@ class InputDeviceManager(
             cfg.hardKeyboardHidden != Configuration.HARDKEYBOARDHIDDEN_YES
     }
 
-    private fun shouldHideKeyboardArea(): Boolean =
-        when (hideVirtualKeyboardMode) {
-            HideVirtualKeyboardMode.NEVER -> false
-            HideVirtualKeyboardMode.ALWAYS -> true
-            HideVirtualKeyboardMode.AUTO -> hasHardwareKeyboard()
-        }
+    private fun shouldHideKeyboardArea(): Boolean = when (hideVirtualKeyboardMode) {
+        HideVirtualKeyboardMode.NEVER -> false
+        HideVirtualKeyboardMode.ALWAYS -> true
+        HideVirtualKeyboardMode.AUTO -> hasHardwareKeyboard()
+    }
 
     private fun setupInputViewCallback(isVirtual: Boolean) {
         val v = inputView ?: return

--- a/app/src/main/java/com/osfans/trime/ime/core/InputView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/InputView.kt
@@ -24,6 +24,7 @@ import com.osfans.trime.data.prefs.AppPrefs
 import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.Theme
 import com.osfans.trime.ime.bar.InputBarDelegate
+import com.osfans.trime.ime.bar.ToolbarPosition
 import com.osfans.trime.ime.broadcast.EnterKeyDisplayDelegate
 import com.osfans.trime.ime.broadcast.InputBroadcaster
 import com.osfans.trime.ime.candidates.popup.PopupCandidatesMode
@@ -104,6 +105,7 @@ class InputView(
 
     private val inlinePreeditMode by AppPrefs.defaultInstance().general.inlinePreeditMode
     private val candidatesMode by AppPrefs.defaultInstance().candidates.mode
+    private val toolbarPosition by AppPrefs.defaultInstance().keyboard.toolbarPosition
 
     private val keyboardSidePadding = theme.generalStyle.keyboardPadding
     private val keyboardSidePaddingLandscape = theme.generalStyle.keyboardPaddingLand
@@ -150,6 +152,7 @@ class InputView(
 
         keyboardBackground.imageDrawable = ColorManager.getDrawable("keyboard_background")
 
+        val isToolbarTop = toolbarPosition == ToolbarPosition.TOP
         keyboardView =
             constraintLayout {
                 isMotionEventSplittingEnabled = true
@@ -162,31 +165,50 @@ class InputView(
                 add(
                     inputBar.view,
                     lParams(matchParent, dp(inputBar.themedHeight)) {
-                        topOfParent()
                         centerHorizontally()
+                        if (isToolbarTop) {
+                            topOfParent()
+                        } else {
+                            above(bottomPaddingSpace)
+                        }
                     },
                 )
                 add(
                     leftPaddingSpace,
                     lParams {
-                        below(inputBar.view)
                         startOfParent()
-                        bottomOfParent()
+                        if (isToolbarTop) {
+                            below(inputBar.view)
+                            bottomOfParent()
+                        } else {
+                            topOfParent()
+                            above(inputBar.view)
+                        }
                     },
                 )
                 add(
                     rightPaddingSpace,
                     lParams {
-                        below(inputBar.view)
                         endOfParent()
-                        bottomOfParent()
+                        if (isToolbarTop) {
+                            below(inputBar.view)
+                            bottomOfParent()
+                        } else {
+                            topOfParent()
+                            above(inputBar.view)
+                        }
                     },
                 )
                 add(
                     windowManager.view,
                     lParams {
-                        below(inputBar.view)
-                        above(bottomPaddingSpace)
+                        if (isToolbarTop) {
+                            below(inputBar.view)
+                            above(bottomPaddingSpace)
+                        } else {
+                            topOfParent()
+                            above(inputBar.view)
+                        }
                     },
                 )
                 add(
@@ -342,6 +364,16 @@ class InputView(
 
     @RequiresApi(Build.VERSION_CODES.R)
     fun handleInlineSuggestions(response: InlineSuggestionsResponse): Boolean = inputBar.handleInlineSuggestions(response)
+
+    /**
+     * Show or hide the virtual keyboard area within the InputView while keeping the toolbar
+     * visible. Used to render a toolbar-only IME on devices with a hardware keyboard.
+     */
+    fun setKeyboardAreaVisible(visible: Boolean) {
+        val target = if (visible) View.VISIBLE else View.GONE
+        if (windowManager.view.visibility == target) return
+        windowManager.view.visibility = target
+    }
 
     override fun onDetachedFromWindow() {
         ViewCompat.setOnApplyWindowInsetsListener(this, null)

--- a/app/src/main/java/com/osfans/trime/ime/core/InputView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/InputView.kt
@@ -375,6 +375,14 @@ class InputView(
         windowManager.view.visibility = target
     }
 
+    /**
+     * Flip the virtual keyboard area visibility for the current input session. Does not change
+     * the persistent preference — next IME activation reverts to the configured default.
+     */
+    fun toggleKeyboardArea() {
+        setKeyboardAreaVisible(windowManager.view.visibility != View.VISIBLE)
+    }
+
     override fun onDetachedFromWindow() {
         ViewCompat.setOnApplyWindowInsetsListener(this, null)
         // cancel the notification job and clear all broadcast receivers,

--- a/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
@@ -94,7 +94,11 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
     private var cursorUpdateIndex = 0
 
     private val recreateInputViewPrefs: Array<PreferenceDelegate<*>> =
-        arrayOf(prefs.keyboard.hideInputBar)
+        arrayOf(
+            prefs.keyboard.hideInputBar,
+            prefs.keyboard.toolbarPosition,
+            prefs.keyboard.hideVirtualKeyboard,
+        )
 
     @Keep
     private val recreateInputViewListener =

--- a/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
@@ -781,6 +781,10 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
         }
     }
 
+    fun toggleKeyboardArea() {
+        inputView?.toggleKeyboardArea()
+    }
+
     fun shareText(): Boolean {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             val ic = currentInputConnection ?: return false

--- a/app/src/main/java/com/osfans/trime/ime/keyboard/CommonKeyboardActionListener.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/CommonKeyboardActionListener.kt
@@ -200,6 +200,7 @@ class CommonKeyboardActionListener {
                     "apply" -> handleApplyCommand(arg)
                     "share_text" -> service.shareText()
                     "select_candidate" -> handleSelectCandidate(arg)
+                    "toggle_keyboard" -> service.toggleKeyboardArea()
                     else -> handleIntentAction(action.command, arg)
                 }
             }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -172,6 +172,13 @@
     <string name="deploy_failure">部署失败</string>
     <string name="view_deploy_failure_log">部署失败。点此查看错误日志。</string>
     <string name="hide_input_bar">隐藏输入工具栏</string>
+    <string name="toolbar_position">工具栏位置</string>
+    <string name="toolbar_position_top">顶部</string>
+    <string name="toolbar_position_bottom">底部</string>
+    <string name="hide_virtual_keyboard">隐藏虚拟键盘</string>
+    <string name="hide_virtual_keyboard_never">从不</string>
+    <string name="hide_virtual_keyboard_auto">自动（检测硬件键盘）</string>
+    <string name="hide_virtual_keyboard_always">始终隐藏</string>
     <string name="navbar_bkg_none">无背景</string>
     <string name="navbar_bkg_color_only">跟随键盘背景色</string>
     <string name="navbar_bkg_full">键盘背景图片</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -173,6 +173,13 @@
     <string name="deploy_failure">部署失敗</string>
     <string name="view_deploy_failure_log">部署失敗。點此檢視錯誤日誌。</string>
     <string name="hide_input_bar">隱藏輸入工具欄</string>
+    <string name="toolbar_position">工具欄位置</string>
+    <string name="toolbar_position_top">頂部</string>
+    <string name="toolbar_position_bottom">底部</string>
+    <string name="hide_virtual_keyboard">隱藏虛擬鍵盤</string>
+    <string name="hide_virtual_keyboard_never">從不</string>
+    <string name="hide_virtual_keyboard_auto">自動（偵測硬體鍵盤）</string>
+    <string name="hide_virtual_keyboard_always">始終隱藏</string>
     <string name="navbar_bkg_none">無背景</string>
     <string name="navbar_bkg_color_only">跟隨鍵盤背景色</string>
     <string name="navbar_bkg_full">鍵盤背景圖片</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -173,6 +173,13 @@
     <string name="deploy_failure">Deploy failure</string>
     <string name="view_deploy_failure_log">Deploy failure. Click here to view error log.</string>
     <string name="hide_input_bar">Hide input bar</string>
+    <string name="toolbar_position">Toolbar position</string>
+    <string name="toolbar_position_top">Top</string>
+    <string name="toolbar_position_bottom">Bottom</string>
+    <string name="hide_virtual_keyboard">Hide virtual keyboard</string>
+    <string name="hide_virtual_keyboard_never">Never</string>
+    <string name="hide_virtual_keyboard_auto">Auto (detect hardware keyboard)</string>
+    <string name="hide_virtual_keyboard_always">Always</string>
     <string name="navbar_bkg_none">No background</string>
     <string name="navbar_bkg_color_only">Follow keyboard color</string>
     <string name="navbar_bkg_full">Keyboard background image</string>


### PR DESCRIPTION
## Summary

Adds three related capabilities for users on devices with a hardware
keyboard (e.g. Unihertz Titan / Titan 2, BlackBerry-style phones,
foldables with detachable keyboards, tablets with Bluetooth keyboards)
and for anyone who wants a more flexible IME layout:

1. **`toolbar_position` preference** — render the toolbar at the
   **top** (default, current behavior) or **bottom** of the InputView.
2. **`hide_virtual_keyboard` preference** — `NEVER` (default) /
   `AUTO` / `ALWAYS`. `AUTO` detects a connected physical keyboard via
   `Configuration.keyboard` + `hardKeyboardHidden` and renders a
   **toolbar-only** surface (toolbar + candidates + clipboard / inline
   suggestions stay; the soft key grid is hidden).
3. **`toggle_keyboard` function command** — a runtime, session-only
   toggle that flips the virtual keyboard area visibility without
   touching the persistent preference, so users can pop the soft keys
   up briefly (emoji input, candidate scrolling, one-handed text)
   without changing their default.

All three are independent and additive; existing users keep current
behavior because every new pref defaults to "off / never / top".

## Motivation

There's a growing set of Android devices that ship a hardware keyboard
(Titan series being the most prominent) and some users prefer to drive
Trime entirely from physical keys while still wanting the candidate
bar, clipboard suggestions, and quick-action toolbar visible. Today
the IME is all-or-nothing: either the full soft keyboard is shown
(wasting half the screen) or the IME is hidden entirely (losing
candidates and the toolbar).

This PR makes that surface available to themes and to runtime actions
without forcing any layout decisions on users who don't want them.

## What changed

### 1. New preferences (auto-surface in Keyboard settings)

`AppPrefs.kt`:

```kotlin
val toolbarPosition =
    enum(R.string.toolbar_position, TOOLBAR_POSITION, ToolbarPosition.TOP)

val hideVirtualKeyboard =
    enum(R.string.hide_virtual_keyboard, HIDE_VIRTUAL_KEYBOARD, HideVirtualKeyboardMode.NEVER)
```

Two new enums in their respective packages:

```kotlin
// ime/bar/ToolbarPosition.kt
enum class ToolbarPosition(...) { TOP, BOTTOM }

// ime/core/HideVirtualKeyboardMode.kt
enum class HideVirtualKeyboardMode(...) { NEVER, AUTO, ALWAYS }
```

Both are registered in `recreateInputViewPrefs` so toggling them in
settings recreates the input view immediately — same pattern as the
existing `hide_input_bar` preference.

### 2. Toolbar position (TOP / BOTTOM)

`InputView.kt` — the four `ConstraintLayout` children
(`inputBar`, `leftPaddingSpace`, `rightPaddingSpace`, `windowManager.view`)
have their vertical anchors switched on a single `isToolbarTop`
boolean. Horizontal anchors and dimensions are unchanged, so themes
that depend on padding / split layouts are unaffected.

### 3. Virtual-keyboard hiding (NEVER / AUTO / ALWAYS)

`InputDeviceManager.kt`:

```kotlin
private fun hasHardwareKeyboard(): Boolean {
    val cfg = inputView?.resources?.configuration ?: return false
    return cfg.keyboard != Configuration.KEYBOARD_NOKEYS &&
        cfg.hardKeyboardHidden != Configuration.HARDKEYBOARDHIDDEN_YES
}

private fun shouldHideKeyboardArea(): Boolean = when (hideVirtualKeyboardMode) {
    HideVirtualKeyboardMode.NEVER -> false
    HideVirtualKeyboardMode.ALWAYS -> true
    HideVirtualKeyboardMode.AUTO -> hasHardwareKeyboard()
}
```

In `setupInputViewCallback`, when the keyboard area should be hidden
the InputView stays attached (`View.VISIBLE`) so the toolbar and
suggestions remain interactive — only `windowManager.view` (the soft
key grid) is hidden. This is the crucial bit: previously a hidden IME
also meant a hidden toolbar.

`InputView.kt` exposes a small helper:

```kotlin
fun setKeyboardAreaVisible(visible: Boolean)  // no-op if already in target state
fun toggleKeyboardArea()                       // flip + delegate
```

### 4. `toggle_keyboard` function command

`CommonKeyboardActionListener.kt` — one line added to
`handleFunctionCommand`:

```kotlin
"toggle_keyboard" -> service.toggleKeyboardArea()
```

`TrimeInputMethodService.toggleKeyboardArea()` is a thin pass-through
to `inputView?.toggleKeyboardArea()` (null-safe — no-op if the
InputView hasn't been created yet).

The toggle is **session-only**: it does not write to SharedPreferences
and the next IME activation falls back to whatever
`hide_virtual_keyboard` says. This makes the command safe to bind to
gestures / long-presses without risk of leaving the user in a sticky
changed state.

### 5. Strings

New keys in `values/strings.xml`, `values-zh-rCN/strings.xml`,
`values-zh-rTW/strings.xml`:

| key                                  | en                                 |
|--------------------------------------|------------------------------------|
| `toolbar_position`                   | Toolbar position                   |
| `toolbar_position_top`               | Top                                |
| `toolbar_position_bottom`            | Bottom                             |
| `hide_virtual_keyboard`              | Hide virtual keyboard              |
| `hide_virtual_keyboard_never`        | Never                              |
| `hide_virtual_keyboard_auto`         | Auto (detect hardware keyboard)    |
| `hide_virtual_keyboard_always`       | Always                             |

zh-rCN and zh-rTW translations added in the same commit.

## Theme / YAML usage

`toggle_keyboard` is the only piece that needs theme-side wiring. A
typical setup binds it to the existing hide button's long-press, so no
new toolbar slot is consumed:

```yaml
patch:
  "preset_keys/toggle_keyboard":
    label: ⌨️
    send: function
    command: toggle_keyboard

  "tool_bar/hide_button":
    foreground: { style: "ic@keyboard_close" }
    action: Hide
    long_press_action: toggle_keyboard
```

Short-press → close IME (existing behavior). Long-press → flip
keyboard-area visibility while keeping the toolbar.

The `toolbar_position` and `hide_virtual_keyboard` prefs require no
theme changes — they're driven entirely from Settings → Keyboard.

## Compatibility

- **Non-breaking by default.** All new prefs default to current
  behavior (`TOP`, `NEVER`).
- **No public API changes.** `setKeyboardAreaVisible` /
  `toggleKeyboardArea` are new public methods but additive.
- **Unknown commands fall through.** A theme that uses
  `toggle_keyboard` on older builds hits the existing
  `handleIntentAction` fallback and is a no-op — no crash.
- **No schema changes**, no librime changes, no resource breakage.
- **Theme-agnostic.** Toolbar reposition uses ConstraintLayout
  anchors; no hardcoded coordinates.

## Testing

Manually tested on [Android 16, device model — Titan 2] with:

- All combinations of `toolbar_position` × `hide_virtual_keyboard`
  (6 cases).
- HW keyboard attach/detach with `hide_virtual_keyboard = AUTO`
  → verifies `hasHardwareKeyboard()` flip causes `recreateInputView`
  via the standard pref-change listener and lands in the correct
  visibility state.
- `toggle_keyboard` bound to `hide_button` long-press in a custom
  theme → short-press still closes IME; long-press toggles keyboard
  area; switching to another app and back reverts to the configured
  default (confirming the toggle is session-only).
- Existing themes (default, default000, custom) → no visual or
  behavioral regression with new prefs at default values.
- Spotless / ktlint clean (one fixup commit included).

No new automated tests — the existing test suite doesn't cover
`InputDeviceManager` / `InputView` rendering, and this change follows
the patterns of the surrounding code (`hide_input_bar`,
`recreateInputViewPrefs`).

## Screenshots

 - Settings screen showing the two new keyboard preferences
 
<img width="1436" height="1440" alt="Screenshot_20260529-194423" src="https://github.com/user-attachments/assets/5c57483e-1305-4d63-9477-c31ecd6f1a32" />

 - Bottom-positioned toolbar in normal mode
 
<img width="755" height="752" alt="image" src="https://github.com/user-attachments/assets/bb6d7059-f606-421c-a093-a49fa9ab8af6" />

## Commits

Three logically separate commits (kept that way for easier review;
happy to squash if maintainers prefer):

1. `feat(ime): add toolbar position and virtual-keyboard hide prefs`
   — preferences, enums, layout switching, HW-keyboard detection,
     strings, integration with `recreateInputViewPrefs`.
2. `style: inline single-expression when in shouldHideKeyboardArea`
   — Spotless / ktlint fixup for commit 1.
3. `feat(ime): add toggle_keyboard function command`
   — runtime toggle exposed as a function command.

## Related

- Extends the existing `hide_input_bar` pref pattern (same
  registration in `recreateInputViewPrefs`, same auto-surfaced
  switch/enum).
- Adjacent to but does not depend on the candidate / clipboard
  suggestion changes already in `develop`.