### PR TITLE
refactor: create PopupMenu with themedContext

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/core/BaseInputView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/BaseInputView.kt
@@ -27,6 +27,7 @@ import com.osfans.trime.ime.keyboard.InputFeedbackManager
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import splitties.dimensions.dp
+import splitties.views.dsl.core.withTheme
 import kotlin.math.max
 
 abstract class BaseInputView(
@@ -60,6 +61,8 @@ abstract class BaseInputView(
             }
         }
 
+    val themedContext = context.withTheme(android.R.style.Theme_DeviceDefault_Settings)
+
     private var candidateActionMenu: PopupMenu? = null
 
     fun showCandidateActionMenu(idx: Int, text: String, view: View, global: Boolean) {
@@ -74,7 +77,7 @@ abstract class BaseInputView(
         service.lifecycleScope.launch {
             InputFeedbackManager.keyPressVibrate(view, longPress = true)
             candidateActionMenu =
-                PopupMenu(context, view).apply {
+                PopupMenu(themedContext, view).apply {
                     menu.add(title).apply {
                         isEnabled = false
                     }

--- a/app/src/main/java/com/osfans/trime/ime/core/InputView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/InputView.kt
@@ -54,7 +54,6 @@ import splitties.views.dsl.core.add
 import splitties.views.dsl.core.imageView
 import splitties.views.dsl.core.matchParent
 import splitties.views.dsl.core.view
-import splitties.views.dsl.core.withTheme
 import splitties.views.dsl.core.wrapContent
 import splitties.views.imageDrawable
 
@@ -90,7 +89,6 @@ class InputView(
 
     private val updateWindowViewHeightJob: Job
 
-    private val themedContext = context.withTheme(android.R.style.Theme_DeviceDefault_Settings)
     private val inputDepMgr = InputDependencyManager.initialize(this, themedContext, theme, service, rime)
     private val di = inputDepMgr.di
     private val broadcaster: InputBroadcaster by di.instance()
@@ -102,7 +100,6 @@ class InputView(
     private val keyboardWindow: KeyboardWindow by di.instance()
     private val liquidWindow: LiquidWindow by di.instance()
 
-    private val inlinePreeditMode by AppPrefs.defaultInstance().general.inlinePreeditMode
     private val candidatesMode by AppPrefs.defaultInstance().candidates.mode
 
     private val keyboardSidePadding = theme.generalStyle.keyboardPadding


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes # N/A

#### Feature
Describe features of this pull request

Fix the issue that the PopupMenu triggered on a candidate doesn't adapt to Dark Mode.

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

