### PR TITLE
refactor(RimeDispatcher): use SpscArrayQueue to improve performance

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -182,6 +182,7 @@ dependencies {
     implementation(libs.xxpermissions)
     implementation(libs.kodein.di)
     implementation(libs.snakeyaml)
+    implementation(libs.jctools.core)
     implementation(libs.splitties.bitflags)
     implementation(libs.splitties.systemservices)
     implementation(libs.splitties.views.dsl)

--- a/app/src/main/java/com/osfans/trime/core/RimeDispatcher.kt
+++ b/app/src/main/java/com/osfans/trime/core/RimeDispatcher.kt
@@ -13,9 +13,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.jctools.queues.SpscArrayQueue
 import timber.log.Timber
 import java.util.concurrent.Executors
-import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.Semaphore
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.CoroutineContext
 
@@ -55,14 +56,6 @@ class RimeDispatcher(
         }
 
         override fun toString(): String = "WrappedRunnable[${name ?: hashCode()}]"
-
-        companion object {
-            val Empty = WrappedRunnable({}, "Empty")
-        }
-    }
-
-    companion object {
-        private const val JOB_WAITING_LIMIT = 2000L // ms
     }
 
     private val internalDispatcher =
@@ -75,9 +68,11 @@ class RimeDispatcher(
 
     private val mutex = Mutex()
 
-    private val queue = LinkedBlockingQueue<WrappedRunnable>()
+    private val queue = SpscArrayQueue<WrappedRunnable>(64)
 
     private val isRunning = AtomicBoolean(false)
+
+    private val semaphore = Semaphore(0)
 
     /**
      * Start the dispatcher
@@ -91,8 +86,11 @@ class RimeDispatcher(
                     Timber.d("nativeStartup()")
                     controller.nativeStartup()
                     while (isActive && isRunning.get()) {
-                        val block = queue.take()
-                        block.run()
+                        semaphore.acquireUninterruptibly()
+                        while (true) {
+                            val block = queue.poll() ?: break
+                            block.run()
+                        }
                     }
                     Timber.i("nativeFinalize()")
                     controller.nativeFinalize()
@@ -109,10 +107,10 @@ class RimeDispatcher(
         Timber.i("RimeDispatcher stop()")
         return if (isRunning.compareAndSet(true, false)) {
             runBlocking {
-                queue.offer(WrappedRunnable.Empty)
+                semaphore.release()
                 mutex.withLock {
-                    val rest = mutableListOf<WrappedRunnable>()
-                    queue.drainTo(rest)
+                    val rest = queue.toList()
+                    queue.clear()
                     rest
                 }
             }
@@ -129,5 +127,10 @@ class RimeDispatcher(
             throw IllegalStateException("Dispatcher is not in running state!")
         }
         queue.offer(WrappedRunnable(block))
+        semaphore.release()
+    }
+
+    companion object {
+        private const val JOB_WAITING_LIMIT = 2000L // ms
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ iconics-core = { module = "com.mikepenz:iconics-core", version.ref = "iconics" }
 community-material-typeface = { module = "com.mikepenz:community-material-typeface", version = "7.0.96.1-kotlin" }
 kodein-di = { module = "org.kodein.di:kodein-di", version = "7.30.0" }
 snakeyaml = { module = "org.yaml:snakeyaml", version = "2.6" }
+jctools-core = { module = "org.jctools:jctools-core", version = "4.0.6" }
 splitties-bitflags = { module = "com.louiscad.splitties:splitties-bitflags", version.ref = "splitties" }
 splitties-systemservices = { module = "com.louiscad.splitties:splitties-systemservices", version.ref = "splitties" }
 splitties-views-dsl = { module = "com.louiscad.splitties:splitties-views-dsl", version.ref = "splitties" }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #N/A

#### Feature
Describe features of this pull request

JCTools is a lightweight library providing high performance lockless queue such as SpscArrayQueue, while "Spsc" means "Single producer and single consumer". It's more appropriate than ConcurrentLinkedQueue or LinkedBlockingQueue for the dedicated event dispatcher, in our case, RimeDispatcher, to process API calling events.

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

