### PR TITLE
fix: Save & restore `isAsciiMode` after it automatically changed

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardWindow.kt
+++ b/app/src/main/java/com/osfans/trime/ime/keyboard/KeyboardWindow.kt
@@ -75,6 +75,7 @@ class KeyboardWindow :
     private var currentKeyboardId = ""
     private var lastKeyboardId = ""
     private var lastLockKeyboardId = ""
+    private var tempAsciiMode: Boolean? = null
     private val cachedKeyboards = mutableMapOf<String, Pair<Keyboard, KeyboardView>>()
     private val currentKeyboard: Keyboard? get() = cachedKeyboards[currentKeyboardId]?.first
     private val currentKeyboardView: KeyboardView? get() = cachedKeyboards[currentKeyboardId]?.second
@@ -207,22 +208,15 @@ class KeyboardWindow :
     }
 
     override fun onStartInput(info: EditorInfo) {
-        var tempAsciiMode = false
         val targetKeyboard =
             when (info.imeOptions and EditorInfo.IME_FLAG_FORCE_ASCII) {
-                EditorInfo.IME_FLAG_FORCE_ASCII -> {
-                    tempAsciiMode = true
-                    ".ascii"
-                }
+                EditorInfo.IME_FLAG_FORCE_ASCII -> ".ascii"
                 else -> {
                     when (info.inputType and InputType.TYPE_MASK_CLASS) {
                         InputType.TYPE_CLASS_NUMBER,
                         InputType.TYPE_CLASS_PHONE,
                         InputType.TYPE_CLASS_DATETIME,
-                        -> {
-                            tempAsciiMode = true
-                            "number"
-                        }
+                        -> "number"
                         InputType.TYPE_CLASS_TEXT -> {
                             when (info.inputType and InputType.TYPE_MASK_VARIATION) {
                                 InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS,
@@ -230,10 +224,7 @@ class KeyboardWindow :
                                 InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD,
                                 InputType.TYPE_TEXT_VARIATION_WEB_EMAIL_ADDRESS,
                                 InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD,
-                                -> {
-                                    tempAsciiMode = true
-                                    ".ascii"
-                                }
+                                -> ".ascii"
                                 else -> ""
                             }
                         }
@@ -242,16 +233,26 @@ class KeyboardWindow :
                 }
             }
         switchKeyboard(targetKeyboard)
-        currentKeyboard?.let {
-            val isAsciiMode = rime.run { statusCached }.isAsciiMode
-            if (tempAsciiMode) {
-                if (!isAsciiMode) {
-                    service.postRimeJob { setRuntimeOption("ascii_mode", true) }
+        val isAsciiMode = rime.run { statusCached }.isAsciiMode
+        if (targetKeyboard == ".ascii" || targetKeyboard == "number") {
+            if (tempAsciiMode == null) {
+                tempAsciiMode = isAsciiMode
+            }
+            if (!isAsciiMode) {
+                service.postRimeJob { setRuntimeOption("ascii_mode", true) }
+            }
+        } else {
+            tempAsciiMode?.let { saved ->
+                if (isAsciiMode != saved) {
+                    service.postRimeJob { setRuntimeOption("ascii_mode", saved) }
                 }
-            } else if (theme.generalStyle.resetAsciiModeOnFocusChange) {
-                val targetMode = if (it.resetAsciiMode) it.asciiMode else it.lastAsciiMode
-                if (isAsciiMode != targetMode) {
-                    service.postRimeJob { setRuntimeOption("ascii_mode", targetMode) }
+                tempAsciiMode = null
+            } ?: currentKeyboard?.let {
+                if (theme.generalStyle.resetAsciiModeOnFocusChange) {
+                    val targetMode = if (it.resetAsciiMode) it.asciiMode else it.lastAsciiMode
+                    if (isAsciiMode != targetMode) {
+                        service.postRimeJob { setRuntimeOption("ascii_mode", targetMode) }
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #2036

#### Feature
Save & restore `isAsciiMode` after it automatically changed

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

