### PR TITLE
refactor: avoid setting internal option via rime

### DIFF
--- a/app/src/main/java/com/osfans/trime/core/Rime.kt
+++ b/app/src/main/java/com/osfans/trime/core/Rime.kt
@@ -68,8 +68,11 @@ class Rime :
 
     private val inlinePreeditMode by AppPrefs.defaultInstance().general.inlinePreeditMode
     private val showAsciiSwitchTips by AppPrefs.defaultInstance().general.asciiSwitchTips
-    private var lastAsciiTipsText = ""
+
     private var asciiSwitchTipsJob: Job? = null
+    private var isNullInputType = true
+    private var lastAsciiTipsText = ""
+    private var pagingMode = false
 
     init {
         if (lifecycle.currentState != RimeLifecycle.State.STOPPED) {
@@ -187,11 +190,19 @@ class Rime :
         getRimeOption(option)
     }
 
+    override suspend fun setNullInputType(value: Boolean) = withRimeContext {
+        isNullInputType = value
+    }
+
     override suspend fun getCandidates(
         startIndex: Int,
         limit: Int,
     ): Array<CandidateProto> = withRimeContext {
         getRimeCandidates(startIndex, limit)
+    }
+
+    override suspend fun setCandidatePagingMode(enabled: Boolean) = withRimeContext {
+        pagingMode = enabled
     }
 
     private fun startRime(fullCheck: Boolean) {
@@ -245,7 +256,7 @@ class Rime :
         if (context.composition.length <= 0 && lastAsciiTipsText != asciiTipsText) {
             showAsciiSwitchTips()
         }
-        if (getRimeOption("paging_mode")) {
+        if (pagingMode) {
             handleRimeMessage(7, arrayOf(context.menu))
         } else {
             val bulk = getRimeBulkCandidates()
@@ -255,7 +266,7 @@ class Rime :
     }
 
     private fun handlePreedit(composition: CompositionProto) {
-        val mode = if (getRimeOption("no_inline_preedit")) {
+        val mode = if (isNullInputType) {
             InlinePreeditMode.DISABLE
         } else {
             inlinePreeditMode

--- a/app/src/main/java/com/osfans/trime/core/RimeApi.kt
+++ b/app/src/main/java/com/osfans/trime/core/RimeApi.kt
@@ -81,8 +81,12 @@ interface RimeApi {
 
     suspend fun getRuntimeOption(option: String): Boolean
 
+    suspend fun setNullInputType(value: Boolean)
+
     suspend fun getCandidates(
         startIndex: Int,
         limit: Int,
     ): Array<CandidateProto>
+
+    suspend fun setCandidatePagingMode(enabled: Boolean)
 }

--- a/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
@@ -81,7 +81,7 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
     private val navBarManager = NavigationBarManager()
     private val inputDeviceManager = InputDeviceManager { useVirtualKeyboard, useCandidatesView ->
         postRimeJob {
-            setRuntimeOption("paging_mode", useCandidatesView)
+            setCandidatePagingMode(useCandidatesView)
         }
         currentInputConnection?.monitorCursorAnchor(useCandidatesView)
         window.window?.let {
@@ -516,7 +516,7 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
                 // when input restarts in the same editor, clear previous composition
                 clearComposition()
             }
-            setRuntimeOption("no_inline_preedit", isNullType)
+            setNullInputType(isNullType)
         }
     }
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes # N/A

#### Feature
Describe features of this pull request

As the explain in commit f8799aaa4c3ef4f1b1b3a6a89238d8a9d5925350,  setting rime option will reset candidate page index each time. And options will be reset after deploying or rime restarting. So we need to add APIs to use internal variables on Kotlin side.

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

