### PR TITLE
feat: allow ignoring system gesture insets

### DIFF
--- a/app/src/main/java/com/osfans/trime/data/prefs/AppPrefs.kt
+++ b/app/src/main/java/com/osfans/trime/data/prefs/AppPrefs.kt
@@ -427,6 +427,7 @@ class AppPrefs(
         companion object {
             const val UI_MODE = "ui_mode"
             const val SHOW_APP_ICON = "show_app_icon"
+            const val IGNORE_SYSTEM_GESTURE_INSETS = "ignore_system_gesture_insets"
         }
 
         enum class UiMode(override val stringRes: Int) : PreferenceDelegateEnum {
@@ -441,6 +442,11 @@ class AppPrefs(
             SHOW_APP_ICON,
             true,
             R.string.only_available_on_some_roms,
+        )
+        val ignoreSystemGestureInsets = switch(
+            R.string.ignore_system_gesture_insets,
+            IGNORE_SYSTEM_GESTURE_INSETS,
+            false,
         )
     }
 }

--- a/app/src/main/java/com/osfans/trime/ime/core/BaseInputView.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/BaseInputView.kt
@@ -19,6 +19,7 @@ import androidx.lifecycle.lifecycleScope
 import com.osfans.trime.R
 import com.osfans.trime.core.RimeMessage
 import com.osfans.trime.daemon.RimeSession
+import com.osfans.trime.data.prefs.AppPrefs
 import com.osfans.trime.data.theme.ColorManager
 import com.osfans.trime.data.theme.Theme
 import com.osfans.trime.data.theme.ThemeManager
@@ -28,6 +29,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import splitties.dimensions.dp
 import splitties.views.dsl.core.withTheme
+import kotlin.math.max
 
 abstract class BaseInputView(
     val service: TrimeInputMethodService,
@@ -105,21 +107,20 @@ abstract class BaseInputView(
             }
         }
 
+    private val ignoreSystemGestureInsets by AppPrefs.defaultInstance().advanced.ignoreSystemGestureInsets
+
     protected fun getNavBarBottomInset(windowInsets: WindowInsets): Int {
         if (navBarBackground != ThemePrefs.NavbarBackground.FULL) {
             return 0
         }
         val insets = WindowInsetsCompat.toWindowInsetsCompat(windowInsets)
-        val insetsBottom = insets.getInsets(
-            WindowInsetsCompat.Type.navigationBars() or
-                WindowInsetsCompat.Type.mandatorySystemGestures() or
-                WindowInsetsCompat.Type.systemGestures(),
-        ).bottom
-        return if (insetsBottom <= 0) {
-            navBarFrameHeight
-        } else {
-            insetsBottom
+        var mask = WindowInsetsCompat.Type.navigationBars()
+        if (!ignoreSystemGestureInsets) {
+            mask = mask or WindowInsetsCompat.Type.mandatorySystemGestures() or
+                WindowInsetsCompat.Type.systemGestures()
         }
+        val insetsBottom = insets.getInsets(mask).bottom
+        return if (insetsBottom > 0) max(insetsBottom, navBarFrameHeight) else insetsBottom
     }
 
     override fun onAttachedToWindow() {

--- a/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
+++ b/app/src/main/java/com/osfans/trime/ime/core/TrimeInputMethodService.kt
@@ -96,8 +96,10 @@ open class TrimeInputMethodService : LifecycleInputMethodService() {
 
     private var cursorUpdateIndex = 0
 
-    private val recreateInputViewPrefs: Array<PreferenceDelegate<*>> =
-        arrayOf(prefs.keyboard.hideInputBar)
+    private val recreateInputViewPrefs: Array<PreferenceDelegate<*>> = arrayOf(
+        prefs.keyboard.hideInputBar,
+        prefs.advanced.ignoreSystemGestureInsets,
+    )
 
     @Keep
     private val recreateInputViewListener =

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -226,4 +226,5 @@
     <string name="share">分享</string>
     <string name="word_segment">分词</string>
     <string name="star_success">收藏成功</string>
+    <string name="ignore_system_gesture_insets">忽略系统手势边衬区</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -227,4 +227,5 @@
     <string name="share">分享</string>
     <string name="word_segment">分词</string>
     <string name="star_success">收藏成功</string>
+    <string name="ignore_system_gesture_insets">忽略系統手勢插邊</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -227,4 +227,5 @@
     <string name="share">Share</string>
     <string name="word_segment">Word segment</string>
     <string name="star_success">Star success</string>
+    <string name="ignore_system_gesture_insets">Ignore system gesture insets</string>
 </resources>


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes # N/A

#### Feature
Describe features of this pull request

The bottom margin may look too high on some ROMs, so make a option to allow users to ignore system gesture insets to make the virtual keyboard more fit to navbar frame (if exists).

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

