### PR TITLE
refactor: disable popup menu icon showing on Samsung OneUI

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/clipboard/ClipboardAdapter.kt
+++ b/app/src/main/java/com/osfans/trime/ime/clipboard/ClipboardAdapter.kt
@@ -14,6 +14,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.osfans.trime.R
 import com.osfans.trime.data.db.DatabaseBean
 import com.osfans.trime.data.theme.Theme
+import com.osfans.trime.util.DeviceUtils
 import com.osfans.trime.util.item
 import splitties.resources.styledColor
 import kotlin.math.min
@@ -111,7 +112,7 @@ abstract class ClipboardAdapter(
                 menu.item(R.string.delete, R.drawable.ic_baseline_delete_24, iconTint) {
                     onDelete(bean.id)
                 }
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && !DeviceUtils.isSamsungOneUI) {
                     popup.setForceShowIcon(true)
                 }
                 popup.setOnDismissListener { p ->


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2015 - 2024 Rime community

SPDX-License-Identifier: GPL-3.0-or-later
-->

## Pull request

#### Issue tracker
Fixes will automatically close the related issues
<!-- Each issue should be on it's own line -->
Fixes #1997 

#### Feature
Describe features of this pull request

#### Code of conduct
- [x] [CONTRIBUTING](CONTRIBUTING.md)

#### Code style
- [x] `make sytle-lint`
- [x] [Conventional Commits](https://www.conventionalcommits.org/)

#### Build pass
- [x] `make debug`

#### Manually test
- [x] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub Action CI pass
4. At least one contributor review and approve
5. Merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

