### PR TITLE
fix(toolbar): center CJK text vertically in tool buttons

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/bar/ui/ToolButton.kt
+++ b/app/src/main/java/com/osfans/trime/ime/bar/ui/ToolButton.kt
@@ -7,6 +7,7 @@ package com.osfans.trime.ime.bar.ui
 
 import android.content.Context
 import android.content.res.ColorStateList
+import android.graphics.Rect
 import android.graphics.drawable.GradientDrawable
 import android.graphics.drawable.LayerDrawable
 import android.graphics.drawable.ShapeDrawable
@@ -117,8 +118,14 @@ class ToolButton : GestureFrame {
             ContentType.TEXT -> {
                 text?.let { label.text = it }
                 label.textSize = foreground.fontSize
+                label.includeFontPadding = false
                 label.padding = dp(foreground.padding)
                 label.typeface = FontManager.getTypeface("toolbar_font")
+                val fm = label.paint.fontMetrics
+                val bounds = Rect()
+                label.paint.getTextBounds(label.text.toString(), 0, label.text.length, bounds)
+                val offset = (fm.ascent + fm.descent) / 2f - (bounds.top + bounds.bottom) / 2f
+                label.translationY = offset
                 add(label, lParams(wrapContent, wrapContent, gravityCenter))
             }
             ContentType.LOCAL_IMAGE -> drawable?.let { image.setImageDrawable(it) }


### PR DESCRIPTION
> This is the second option. Both options (includeFontPadding=false, and this visual-bounds centering) work on VIVO OriginOS 6. This second option is the more robust one — it centers by the actual glyph bounds, but I don't have other OS to test with , e.g. LineageOS 23. Hope it helps.

## Summary

Toolbar tool buttons using CJK labels (e.g. `option_styles: ["中", "En"]`) render the CJK glyph visually lower than latin text, so it does not line up with the surrounding icon buttons.

## Root cause

The label `TextView` ([ToolButton.kt](app/src/main/java/com/osfans/trime/ime/bar/ui/ToolButton.kt)) centers text by font metrics, but CJK glyphs occupy only part of the font box. With the default `includeFontPadding = true` (and even with it disabled), the visible 中 glyph sits below the box center because its visual bounds differ from the font metrics, and this differs per font/system.

## Fix

Disable the extra font padding, then offset the label by the difference between the font-box center and the actual glyph bounds:

```kotlin
label.includeFontPadding = false
val fm = label.paint.fontMetrics
val bounds = Rect()
label.paint.getTextBounds(label.text.toString(), 0, label.text.length, bounds)
val offset = (fm.ascent + fm.descent) / 2f - (bounds.top + bounds.bottom) / 2f
label.translationY = offset
```

This computes the offset per glyph from the active typeface, so it centers any text visually regardless of font or system.

## Verification

- Reproduced the off-center 中 label on a clean build.
- This fix centers it correctly. The first option (`includeFontPadding = false` + `Gravity.CENTER`) also works on VIVO OriginOS 6.
- Only affects `ContentType.TEXT` tool buttons; icon buttons are untouched.

Closes #2062